### PR TITLE
Fix sed replacement of spring.sql.init.mode in backend Dockerfile.

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y supervisor openssl zip unzip curl && \
     sed -i "s|server\.schema.*|server.schema=${protocol}|g" /opt/${project_name}/${project_name}/BOOT-INF/classes/application.properties  && \
     sed -i "s|server\.servlet\.context-path.*|server.servlet.context-path=/${project_name}|g" /opt/${project_name}/${project_name}/BOOT-INF/classes/application.properties  && \
     sed -i "s|enable\.guest\.user.*|enable.guest.user=${enable_guest_user}|g" /opt/${project_name}/${project_name}/BOOT-INF/classes/application.properties  && \
-    sed -i "s|spring\.sql\.init\.mode\.*|spring.sql.init.mode=${database_populate_default_data}|g" /opt/${project_name}/${project_name}/BOOT-INF/classes/application.properties  && \
+    sed -i "s|spring\.sql\.init\.mode.*|spring.sql.init.mode=${database_populate_default_data}|g" /opt/${project_name}/${project_name}/BOOT-INF/classes/application.properties  && \
     #Add the modified files to the jar again
     cd /opt/${project_name}/${project_name} && \
     zip /opt/${project_name}/kendo-tournament-backend.jar BOOT-INF/classes/application.properties && \


### PR DESCRIPTION
Previously application.properties ended up with the value twice, e.g. `spring.sql.init.mode=always=always`.