### PR TITLE
docker: Provide timezone as argument

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,6 +1,7 @@
 COMPOSE_PROJECT_NAME=kendo_tournament
 machine_domain=localhost
 email=myemail@domain.com
+timezone=Europe/Madrid
 release=v2.14.2
 version=2.14.2
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -14,6 +14,7 @@ ARG jwt_expiration
 ARG jwt_guest_expiration
 ARG jwt_secret
 ARG jwt_ip_check
+ARG timezone
 ARG enable_guest_user
 ARG database_populate_default_data
 
@@ -23,7 +24,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-16-openjdk
 ENV PATH "$PATH:${JAVA_HOME}/bin"
 
 #Set timezone.
-ENV TZ=Europe/Madrid
+ENV TZ=${timezone}
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 #Copy libraries

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       context: ./traefik
       args:
         - email
+        - timezone
     image: "kendo-tournament-rproxy"
     container_name: "kendo-tournament-rproxy"
     command:
@@ -68,6 +69,7 @@ services:
         - release
         - machine_domain
         - protocol
+        - timezone
         - websocket_protocol
     image: kendo-tournament-frontend
     restart: always
@@ -121,6 +123,7 @@ services:
         - jwt_guest_expiration
         - jwt_secret
         - jwt_ip_check
+        - timezone
         - enable_guest_user
         - database_populate_default_data
     image: kendo-tournament-backend

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -3,12 +3,13 @@ FROM nginx:alpine
 ARG release
 ARG machine_domain
 ARG protocol
+ARG timezone
 ARG websocket_protocol
 
 ENV HTML_ROOT_FOLDER /www
 
 #Set timezone.
-ENV TZ=Europe/Madrid
+ENV TZ=${timezone}
 RUN apk add --no-cache curl tzdata && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/docker/traefik/Dockerfile
+++ b/docker/traefik/Dockerfile
@@ -1,9 +1,10 @@
 FROM traefik:latest
 
 ARG email
+ARG timezone
 
 #Set timezone.
-ENV TZ=Europe/Madrid
+ENV TZ=${timezone}
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 #Prepare folders structure


### PR DESCRIPTION
Default remains Europe/Madrid

Again, please feel free to reject this PR. My aim was to reduce duplication across files, but I'm still familiarising myself with Docker Compose and this code base.