### PR TITLE
test: fix orphaned coverage test classes and extend crypto converter tests

### DIFF
--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/controller/CacheControllerTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/controller/CacheControllerTest.java
@@ -1,0 +1,85 @@
+package com.softwaremagico.kt.core.controller;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Core)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Test(groups = "cacheController")
+public class CacheControllerTest {
+
+    @Mock
+    private CacheManager mockCacheManager;
+
+    @Mock
+    private Cache mockCache1;
+
+    @Mock
+    private Cache mockCache2;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void deleteAllCache_withNullCacheManager_expectNoException() {
+        final CacheController controller = new CacheController(null);
+        controller.deleteAllCache();
+    }
+
+    @Test
+    public void deleteAllCache_withCacheManager_expectAllCachesInvalidated() {
+        when(mockCacheManager.getCacheNames()).thenReturn(List.of("cache1", "cache2"));
+        when(mockCacheManager.getCache("cache1")).thenReturn(mockCache1);
+        when(mockCacheManager.getCache("cache2")).thenReturn(mockCache2);
+
+        final CacheController controller = new CacheController(mockCacheManager);
+        controller.deleteAllCache();
+
+        verify(mockCache1, times(1)).invalidate();
+        verify(mockCache2, times(1)).invalidate();
+    }
+
+    @Test
+    public void deleteAllCache_withEmptyCacheManager_expectNoInvalidateCalls() {
+        when(mockCacheManager.getCacheNames()).thenReturn(List.of());
+
+        final CacheController controller = new CacheController(mockCacheManager);
+        controller.deleteAllCache();
+
+        verify(mockCacheManager, never()).getCache(anyString());
+    }
+}
+

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/controller/VersionControllerTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/controller/VersionControllerTest.java
@@ -1,0 +1,97 @@
+package com.softwaremagico.kt.core.controller;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Core)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import org.testng.annotations.Test;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+/**
+ * Covers {@link VersionController.NamespaceContextImpl}, the only part of {@link VersionController}
+ * that can be exercised without performing a real network call to GitHub.
+ */
+@Test(groups = "versionController")
+public class VersionControllerTest {
+
+    private static final String DEFAULT_NS = "http://maven.apache.org/POM/4.0.0";
+
+    private NamespaceContext newContext() {
+        final Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("pom", DEFAULT_NS);
+        return new VersionController.NamespaceContextImpl(DEFAULT_NS, namespaces);
+    }
+
+    @Test
+    public void getNamespaceURI_withXmlnsPrefix_expectXmlnsNamespaceUri() {
+        final NamespaceContext context = newContext();
+        assertEquals(context.getNamespaceURI(XMLConstants.XMLNS_ATTRIBUTE), XMLConstants.XMLNS_ATTRIBUTE_NS_URI);
+    }
+
+    @Test
+    public void getNamespaceURI_withXmlPrefix_expectXmlNamespaceUri() {
+        final NamespaceContext context = newContext();
+        assertEquals(context.getNamespaceURI(XMLConstants.XML_NS_PREFIX), XMLConstants.XML_NS_URI);
+    }
+
+    @Test
+    public void getNamespaceURI_withDefaultPrefix_expectDefaultNamespace() {
+        final NamespaceContext context = newContext();
+        assertEquals(context.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX), DEFAULT_NS);
+    }
+
+    @Test
+    public void getNamespaceURI_withKnownPrefix_expectMappedNamespace() {
+        final NamespaceContext context = newContext();
+        assertEquals(context.getNamespaceURI("pom"), DEFAULT_NS);
+    }
+
+    @Test
+    public void getNamespaceURI_withUnknownPrefix_expectNullNamespaceUri() {
+        final NamespaceContext context = newContext();
+        assertEquals(context.getNamespaceURI("unknown"), XMLConstants.NULL_NS_URI);
+    }
+
+    @Test
+    public void getNamespaceURI_withNullPrefix_expectIllegalArgumentException() {
+        final NamespaceContext context = newContext();
+        assertThrows(IllegalArgumentException.class, () -> context.getNamespaceURI(null));
+    }
+
+    @Test
+    public void getPrefix_expectIllegalStateException() {
+        final NamespaceContext context = newContext();
+        assertThrows(IllegalStateException.class, () -> context.getPrefix(DEFAULT_NS));
+    }
+
+    @Test
+    public void getPrefixes_expectIllegalStateException() {
+        final NamespaceContext context = newContext();
+        assertThrows(IllegalStateException.class, () -> context.getPrefixes(DEFAULT_NS));
+    }
+}
+

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/controller/models/ControllerModelsDTOCoverageTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/controller/models/ControllerModelsDTOCoverageTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("all")
-@Test
+@Test(groups = "controllerModelsCoverageTest")
 public class ControllerModelsDTOCoverageTest {
 
     @Test
@@ -53,7 +53,7 @@ public class ControllerModelsDTOCoverageTest {
                 .isEqualTo(same)
                 .hasSameHashCodeAs(same)
                 .isNotEqualTo(differentGrade)
-                
+
                 .hasToString(left.toString());
         assertThat(left.toString()).contains("Achievement").contains("achievementType");
     }
@@ -179,7 +179,7 @@ public class ControllerModelsDTOCoverageTest {
         final AchievementDTO base = this.createAchievementDTO(20, "Nao", "Ito", "Cup", AchievementType.TERMINATOR, AchievementGrade.GOLD);
 
         // this == o branch
-        
+
         // super.equals(o) == false branch (different createdAt/id in ElementDTO)
         final AchievementDTO differentSuper = this.createAchievementDTO(21, "Nao", "Ito", "Cup", AchievementType.TERMINATOR, AchievementGrade.GOLD);
         assertThat(base.equals(differentSuper)).isFalse();
@@ -202,7 +202,7 @@ public class ControllerModelsDTOCoverageTest {
         final RoleDTO base = this.createRoleDTO(30, "Akira", "Kato", RoleType.COMPETITOR);
 
         // this == o branch
-        
+
         // super.equals(o) == false branch
         final RoleDTO differentSuper = this.createRoleDTO(31, "Akira", "Kato", RoleType.COMPETITOR);
         assertThat(base.equals(differentSuper)).isFalse();
@@ -271,7 +271,7 @@ public class ControllerModelsDTOCoverageTest {
                 .isEqualTo(same)
                 .hasSameHashCodeAs(same)
                 .isNotEqualTo(differentCity)
-                
+
                 .hasToString("Dojo A");
 
         final ClubDTO nullName = this.createClubDTO("Dojo B", "ES", "Bilbao");
@@ -318,7 +318,7 @@ public class ControllerModelsDTOCoverageTest {
         final ParticipantDTO base = this.createParticipantDTO(90, "Haru", "Sato");
         base.setClub(this.createClubDTO("Club H", "JP", "Osaka"));
 
-        
+
         final ParticipantDTO anonymous = this.createParticipantDTO(91, "Tmp", "Tmp");
         anonymous.setName(null);
         assertThatThrownBy(anonymous::toString).isInstanceOf(NullPointerException.class);
@@ -375,7 +375,7 @@ public class ControllerModelsDTOCoverageTest {
                 .isEqualTo(same)
                 .hasSameHashCodeAs(same)
                 .isNotEqualTo(differentType)
-                
+
                 .hasToString("Finals");
         assertThat(base.isLocked()).isTrue();
         assertThat(base.getFightSize()).isEqualTo(3);

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/controller/models/TournamentImageDTOTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/controller/models/TournamentImageDTOTest.java
@@ -1,0 +1,118 @@
+package com.softwaremagico.kt.core.controller.models;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Core)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.persistence.values.ImageCompression;
+import com.softwaremagico.kt.persistence.values.TournamentImageType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "tournamentImageDTO")
+public class TournamentImageDTOTest {
+
+    private TournamentImageDTO newDto(byte[] data, TournamentImageType type, ImageCompression compression, boolean defaultImage) {
+        final TournamentImageDTO dto = new TournamentImageDTO();
+        dto.setData(data);
+        dto.setImageType(type);
+        dto.setImageCompression(compression);
+        dto.setDefaultImage(defaultImage);
+        return dto;
+    }
+
+    @Test
+    public void getBase64_withPngCompression_expectPngDataUri() {
+        final TournamentImageDTO dto = newDto(new byte[]{1, 2, 3}, TournamentImageType.BANNER, ImageCompression.PNG, false);
+        assertTrue(dto.getBase64().startsWith("data:image/png;base64,"));
+    }
+
+    @Test
+    public void getBase64_withJpgCompression_expectJpegDataUri() {
+        final TournamentImageDTO dto = newDto(new byte[]{1, 2, 3}, TournamentImageType.BANNER, ImageCompression.JPG, false);
+        assertTrue(dto.getBase64().startsWith("data:image/jpeg;base64,"));
+    }
+
+    @Test
+    public void getBase64_withNullData_expectNull() {
+        final TournamentImageDTO dto = newDto(null, TournamentImageType.BANNER, ImageCompression.PNG, false);
+        assertNull(dto.getBase64());
+    }
+
+    @Test
+    public void equals_withMatchingFields_expectTrue() {
+        final TournamentImageDTO dto1 = newDto(new byte[]{1, 2}, TournamentImageType.PHOTO, ImageCompression.PNG, true);
+        final TournamentImageDTO dto2 = newDto(new byte[]{1, 2}, TournamentImageType.PHOTO, ImageCompression.PNG, true);
+
+        assertEquals(dto1, dto2);
+        assertEquals(dto1.hashCode(), dto2.hashCode());
+    }
+
+    @Test
+    public void equals_withDifferentImageType_expectFalse() {
+        final TournamentImageDTO dto1 = newDto(new byte[]{1, 2}, TournamentImageType.PHOTO, ImageCompression.PNG, false);
+        final TournamentImageDTO dto2 = newDto(new byte[]{1, 2}, TournamentImageType.BANNER, ImageCompression.PNG, false);
+
+        assertNotEquals(dto1, dto2);
+    }
+
+    @Test
+    public void equals_withDifferentData_expectFalse() {
+        final TournamentImageDTO dto1 = newDto(new byte[]{1, 2}, TournamentImageType.PHOTO, ImageCompression.PNG, false);
+        final TournamentImageDTO dto2 = newDto(new byte[]{9, 9}, TournamentImageType.PHOTO, ImageCompression.PNG, false);
+
+        assertNotEquals(dto1, dto2);
+    }
+
+    @Test
+    public void equals_withDifferentDefaultImageFlag_expectFalse() {
+        final TournamentImageDTO dto1 = newDto(new byte[]{1, 2}, TournamentImageType.PHOTO, ImageCompression.PNG, true);
+        final TournamentImageDTO dto2 = newDto(new byte[]{1, 2}, TournamentImageType.PHOTO, ImageCompression.PNG, false);
+
+        assertNotEquals(dto1, dto2);
+    }
+
+    @Test
+    public void equals_withNonTournamentImageDTO_expectFalse() {
+        final TournamentImageDTO dto = newDto(new byte[]{1, 2}, TournamentImageType.PHOTO, ImageCompression.PNG, false);
+        assertFalse(dto.equals("not-a-dto"));
+    }
+
+    @Test
+    public void equals_withItself_expectTrue() {
+        final TournamentImageDTO dto = newDto(new byte[]{1, 2}, TournamentImageType.PHOTO, ImageCompression.PNG, false);
+        assertEquals(dto, dto);
+    }
+
+    @Test
+    public void tournamentAccessors_expectRoundTrip() {
+        final TournamentImageDTO dto = new TournamentImageDTO();
+        final TournamentDTO tournament = new TournamentDTO();
+        dto.setTournament(tournament);
+
+        assertEquals(dto.getTournament(), tournament);
+    }
+}
+

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/converters/AchievementConverterTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/converters/AchievementConverterTest.java
@@ -1,0 +1,162 @@
+package com.softwaremagico.kt.core.converters;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Core)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.controller.models.AchievementDTO;
+import com.softwaremagico.kt.core.controller.models.ParticipantDTO;
+import com.softwaremagico.kt.core.controller.models.ParticipantReducedDTO;
+import com.softwaremagico.kt.core.controller.models.TournamentDTO;
+import com.softwaremagico.kt.core.converters.models.AchievementConverterRequest;
+import com.softwaremagico.kt.core.providers.ParticipantProvider;
+import com.softwaremagico.kt.persistence.entities.Achievement;
+import com.softwaremagico.kt.persistence.entities.Participant;
+import com.softwaremagico.kt.persistence.entities.Tournament;
+import com.softwaremagico.kt.persistence.repositories.TournamentRepository;
+import org.hibernate.LazyInitializationException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+@Test(groups = "achievementConverter")
+public class AchievementConverterTest {
+
+    @Mock
+    private TournamentConverter mockTournamentConverter;
+
+    @Mock
+    private TournamentRepository mockTournamentRepository;
+
+    @Mock
+    private ParticipantReducedConverter mockParticipantReducedConverter;
+
+    @Mock
+    private ParticipantConverter mockParticipantConverter;
+
+    @Mock
+    private ParticipantProvider mockParticipantProvider;
+
+    private AchievementConverter converter;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        converter = new AchievementConverter(mockTournamentConverter, mockTournamentRepository,
+                mockParticipantReducedConverter, mockParticipantConverter, mockParticipantProvider);
+    }
+
+    private Achievement newAchievement() {
+        final Achievement achievement = new Achievement();
+        final Tournament tournament = new Tournament();
+        tournament.setId(5);
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        participant.setId(9);
+        achievement.setTournament(tournament);
+        achievement.setParticipant(participant);
+        return achievement;
+    }
+
+    @Test
+    public void convert_withNormalAccess_expectDirectConversion() {
+        final Achievement achievement = newAchievement();
+        final TournamentDTO tournamentDTO = new TournamentDTO();
+        final ParticipantReducedDTO participantDTO = new ParticipantReducedDTO();
+
+        when(mockTournamentConverter.convert(any())).thenReturn(tournamentDTO);
+        when(mockParticipantReducedConverter.convert(any())).thenReturn(participantDTO);
+
+        final AchievementDTO result = converter.convert(new AchievementConverterRequest(achievement));
+
+        assertSame(result.getTournament(), tournamentDTO);
+        assertSame(result.getParticipant(), participantDTO);
+    }
+
+    @Test
+    public void convert_withLazyTournament_expectFallbackToRepository() {
+        final Achievement achievement = newAchievement();
+        final TournamentDTO tournamentDTO = new TournamentDTO();
+        final ParticipantReducedDTO participantDTO = new ParticipantReducedDTO();
+        final Tournament reloadedTournament = new Tournament();
+        reloadedTournament.setId(5);
+
+        when(mockTournamentConverter.convert(any()))
+                .thenThrow(new LazyInitializationException("lazy tournament"))
+                .thenReturn(tournamentDTO);
+        when(mockTournamentRepository.findById(5)).thenReturn(Optional.of(reloadedTournament));
+        when(mockParticipantReducedConverter.convert(any())).thenReturn(participantDTO);
+
+        final AchievementDTO result = converter.convert(new AchievementConverterRequest(achievement));
+
+        assertSame(result.getTournament(), tournamentDTO);
+    }
+
+    @Test
+    public void convert_withLazyParticipant_expectFallbackToProvider() {
+        final Achievement achievement = newAchievement();
+        final TournamentDTO tournamentDTO = new TournamentDTO();
+        final ParticipantReducedDTO participantDTO = new ParticipantReducedDTO();
+        final Participant reloadedParticipant = new Participant("ID1", "John", "Doe", null);
+        reloadedParticipant.setId(9);
+
+        when(mockTournamentConverter.convert(any())).thenReturn(tournamentDTO);
+        when(mockParticipantReducedConverter.convert(any()))
+                .thenThrow(new LazyInitializationException("lazy participant"))
+                .thenReturn(participantDTO);
+        when(mockParticipantProvider.get(9)).thenReturn(Optional.of(reloadedParticipant));
+
+        final AchievementDTO result = converter.convert(new AchievementConverterRequest(achievement));
+
+        assertSame(result.getParticipant(), participantDTO);
+    }
+
+    @Test
+    public void reverse_withNull_expectNull() {
+        assertNull(converter.reverse(null));
+    }
+
+    @Test
+    public void reverse_expectParticipantAndTournamentReversed() {
+        final AchievementDTO dto = new AchievementDTO();
+        final ParticipantDTO participantDTO = new ParticipantReducedDTO();
+        final TournamentDTO tournamentDTO = new TournamentDTO();
+        dto.setParticipant(participantDTO);
+        dto.setTournament(tournamentDTO);
+
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        final Tournament tournament = new Tournament();
+        when(mockParticipantConverter.reverse(participantDTO)).thenReturn(participant);
+        when(mockTournamentConverter.reverse(tournamentDTO)).thenReturn(tournament);
+
+        final Achievement result = converter.reverse(dto);
+
+        assertSame(result.getParticipant(), participant);
+        assertSame(result.getTournament(), tournament);
+    }
+}
+

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/converters/ParticipantImageConverterTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/converters/ParticipantImageConverterTest.java
@@ -1,0 +1,98 @@
+package com.softwaremagico.kt.core.converters;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Core)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.controller.models.ParticipantImageDTO;
+import com.softwaremagico.kt.core.controller.models.ParticipantReducedDTO;
+import com.softwaremagico.kt.core.converters.models.ParticipantImageConverterRequest;
+import com.softwaremagico.kt.persistence.entities.Participant;
+import com.softwaremagico.kt.persistence.entities.ParticipantImage;
+import com.softwaremagico.kt.persistence.values.ImageFormat;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+@Test(groups = "participantImageConverter")
+public class ParticipantImageConverterTest {
+
+    @Mock
+    private ParticipantConverter mockParticipantConverter;
+
+    @Mock
+    private ParticipantReducedConverter mockParticipantReducedConverter;
+
+    private ParticipantImageConverter converter;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        converter = new ParticipantImageConverter(mockParticipantConverter, mockParticipantReducedConverter);
+    }
+
+    @Test
+    public void convert_expectImageFormatAndParticipantMapped() {
+        final Participant participant = new Participant("ID1", "Name", "Lastname", null);
+        final ParticipantImage entity = new ParticipantImage();
+        entity.setData(new byte[]{1, 2, 3});
+        entity.setImageFormat(ImageFormat.BASE64);
+        entity.setParticipant(participant);
+
+        final ParticipantReducedDTO reducedDTO = new ParticipantReducedDTO();
+        when(mockParticipantReducedConverter.convertElement(any())).thenReturn(reducedDTO);
+
+        final ParticipantImageDTO result = converter.convert(new ParticipantImageConverterRequest(entity));
+
+        assertEquals(result.getImageFormat(), ImageFormat.BASE64);
+        assertSame(result.getParticipant(), reducedDTO);
+    }
+
+    @Test
+    public void reverse_withNull_expectNull() {
+        assertNull(converter.reverse(null));
+    }
+
+    @Test
+    public void reverse_expectImageFormatAndParticipantMapped() {
+        final ParticipantImageDTO dto = new ParticipantImageDTO();
+        dto.setImageFormat(ImageFormat.SVG);
+        final ParticipantReducedDTO reducedDTO = new ParticipantReducedDTO();
+        dto.setParticipant(reducedDTO);
+
+        final Participant participant = new Participant("ID2", "Other", "Name", null);
+        when(mockParticipantConverter.reverse(reducedDTO)).thenReturn(participant);
+
+        final ParticipantImage result = converter.reverse(dto);
+
+        assertEquals(result.getImageFormat(), ImageFormat.SVG);
+        assertSame(result.getParticipant(), participant);
+    }
+}
+
+
+

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/converters/ScoreOfTeamConverterTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/converters/ScoreOfTeamConverterTest.java
@@ -1,0 +1,137 @@
+package com.softwaremagico.kt.core.converters;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Core)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.controller.models.FightDTO;
+import com.softwaremagico.kt.core.controller.models.ScoreOfTeamDTO;
+import com.softwaremagico.kt.core.controller.models.TeamDTO;
+import com.softwaremagico.kt.core.controller.models.TournamentDTO;
+import com.softwaremagico.kt.core.converters.models.ScoreOfTeamConverterRequest;
+import com.softwaremagico.kt.core.score.ScoreOfTeam;
+import com.softwaremagico.kt.persistence.entities.Duel;
+import com.softwaremagico.kt.persistence.entities.Fight;
+import com.softwaremagico.kt.persistence.entities.Team;
+import com.softwaremagico.kt.persistence.entities.Tournament;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "scoreOfTeamConverter")
+public class ScoreOfTeamConverterTest {
+
+    @Mock
+    private TeamConverter mockTeamConverter;
+
+    @Mock
+    private FightConverter mockFightConverter;
+
+    @Mock
+    private DuelConverter mockDuelConverter;
+
+    @Mock
+    private TournamentConverter mockTournamentConverter;
+
+    @Mock
+    private Team mockTeam;
+
+    @Mock
+    private Tournament mockTournament;
+
+    @Mock
+    private Fight mockFight;
+
+    @Mock
+    private Duel mockDuel;
+
+    private ScoreOfTeamConverter converter;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        converter = new ScoreOfTeamConverter(mockTeamConverter, mockFightConverter, mockDuelConverter, mockTournamentConverter);
+        when(mockTeam.getTournament()).thenReturn(mockTournament);
+    }
+
+    @Test
+    public void convert_expectDelegationToAllConverters() {
+        final ScoreOfTeam scoreOfTeam = new ScoreOfTeam();
+        scoreOfTeam.setTeam(mockTeam);
+        scoreOfTeam.setFights(List.of(mockFight));
+        scoreOfTeam.setUnties(List.of(mockDuel));
+        scoreOfTeam.setHits(10);
+        scoreOfTeam.setHitsLost(4);
+
+        final TournamentDTO tournamentDTO = new TournamentDTO();
+        final TeamDTO teamDTO = new TeamDTO();
+        final FightDTO fightDTO = new FightDTO();
+
+        when(mockTournamentConverter.convertElement(any())).thenReturn(tournamentDTO);
+        when(mockTeamConverter.convert(any())).thenReturn(teamDTO);
+        when(mockFightConverter.convertAll(any())).thenReturn(List.of(fightDTO));
+        when(mockDuelConverter.convertAll(any())).thenReturn(List.of());
+
+        final ScoreOfTeamDTO result = converter.convert(new ScoreOfTeamConverterRequest(scoreOfTeam));
+
+        assertSame(result.getTeam(), teamDTO);
+        assertEquals(result.getFights(), List.of(fightDTO));
+        assertTrue(result.getUnties().isEmpty());
+        assertEquals(result.getHits().intValue(), 10);
+        assertEquals(result.getHitsLost().intValue(), 4);
+    }
+
+    @Test
+    public void reverse_withNull_expectNull() {
+        assertNull(converter.reverse(null));
+    }
+
+    @Test
+    public void reverse_expectFightsAndUntiesReversed() {
+        final ScoreOfTeamDTO dto = new ScoreOfTeamDTO();
+        final TeamDTO teamDTO = new TeamDTO();
+        final FightDTO fightDTO = new FightDTO();
+        dto.setTeam(teamDTO);
+        dto.setFights(List.of(fightDTO));
+        dto.setUnties(List.of());
+        dto.setHits(6);
+
+        when(mockTeamConverter.reverse(teamDTO)).thenReturn(mockTeam);
+        when(mockFightConverter.reverse(fightDTO)).thenReturn(mockFight);
+
+        final ScoreOfTeam result = converter.reverse(dto);
+
+        assertSame(result.getTeam(), mockTeam);
+        assertEquals(result.getFights(), List.of(mockFight));
+        assertTrue(result.getUnties().isEmpty());
+        assertEquals(result.getHits().intValue(), 6);
+    }
+}
+

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/csv/ClubCsvTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/csv/ClubCsvTest.java
@@ -1,0 +1,82 @@
+package com.softwaremagico.kt.core.csv;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Core)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.exceptions.InvalidCsvFieldException;
+import com.softwaremagico.kt.persistence.entities.Club;
+import com.softwaremagico.kt.utils.StringUtils;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+@Test(groups = "clubCsvTests")
+public class ClubCsvTest {
+
+    private static final String HEADER = "name;country;city;address;email;phone;web";
+
+    private ClubCsv clubCsv;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        this.clubCsv = new ClubCsv();
+    }
+
+    @Test
+    public void shouldReadSingleClub() {
+        final String csv = HEADER + "\nMyClub;MyCountry;MyCity;MyAddress;my@email.com;123456;http://web.com";
+
+        final List<Club> clubs = this.clubCsv.readCSV(csv);
+
+        assertEquals(clubs.size(), 1);
+        assertEquals(clubs.get(0).getName(), StringUtils.setCase("MyClub"));
+        assertEquals(clubs.get(0).getCountry(), StringUtils.setCase("MyCountry"));
+        assertEquals(clubs.get(0).getCity(), StringUtils.setCase("MyCity"));
+        assertEquals(clubs.get(0).getAddress(), StringUtils.setCase("MyAddress"));
+        assertEquals(clubs.get(0).getEmail(), "my@email.com");
+        assertEquals(clubs.get(0).getPhone(), "123456");
+        assertEquals(clubs.get(0).getWeb(), "http://web.com");
+    }
+
+    @Test
+    public void shouldReadMultipleClubLines() {
+        final String csv = HEADER + "\nClub0;C0;City0;Add0;e0@e.com;000;w0"
+                + "\nClub1;C1;City1;Add1;e1@e.com;111;w1";
+
+        final List<Club> clubs = this.clubCsv.readCSV(csv);
+
+        assertEquals(clubs.size(), 2);
+        assertEquals(clubs.get(0).getName(), "Club0");
+        assertEquals(clubs.get(1).getName(), "Club1");
+    }
+
+    @Test
+    public void shouldThrowExceptionOnInvalidHeader() {
+        final String csv = "name;country;city;address;email;phone;invalid\nMyClub;C;City;Add;e@e.com;123;w";
+
+        assertThrows(InvalidCsvFieldException.class, () -> this.clubCsv.readCSV(csv));
+    }
+}
+

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/csv/CsvReaderUnitTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/csv/CsvReaderUnitTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("all")
-@Test
+@Test(groups = "csvReaderUnit")
 public class CsvReaderUnitTest {
 
     private ClubCsv clubCsvReader;

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/score/ScoreOfTeamTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/score/ScoreOfTeamTest.java
@@ -1,0 +1,179 @@
+package com.softwaremagico.kt.core.score;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Core)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.persistence.entities.Duel;
+import com.softwaremagico.kt.persistence.entities.Fight;
+import com.softwaremagico.kt.persistence.entities.Participant;
+import com.softwaremagico.kt.persistence.entities.Team;
+import com.softwaremagico.kt.persistence.entities.Tournament;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "scoreOfTeam")
+public class ScoreOfTeamTest {
+
+    @Mock
+    private Team team;
+
+    @Mock
+    private Team otherTeam;
+
+    @Mock
+    private Tournament tournament;
+
+    @Mock
+    private Fight wonFight;
+
+    @Mock
+    private Fight drawnUnfinishedFight;
+
+    @Mock
+    private Fight drawnFinishedFight;
+
+    @Mock
+    private Duel wonUntieDuel;
+
+    @Mock
+    private Duel lostUntieDuel;
+
+    @Mock
+    private Participant competitor1;
+
+    @Mock
+    private Participant competitor2;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(team.getTournament()).thenReturn(tournament);
+        when(team.getMembers()).thenReturn(List.of(competitor1));
+
+        // Fight won by "team" against "otherTeam".
+        when(wonFight.getTeam1()).thenReturn(team);
+        when(wonFight.getTeam2()).thenReturn(otherTeam);
+        when(wonFight.getWinner()).thenReturn(team);
+        when(wonFight.getLevel()).thenReturn(2);
+        when(wonFight.isOver()).thenReturn(true);
+        when(wonFight.isDrawFight()).thenReturn(false);
+        when(wonFight.getWonDuels(team)).thenReturn(1);
+        when(wonFight.getDrawDuels(team)).thenReturn(0);
+        when(wonFight.getScore(team)).thenReturn(5);
+        when(wonFight.getScoreAgainst(team)).thenReturn(1);
+
+        // Fight involving "team" but not yet finished (should not count as draw).
+        when(drawnUnfinishedFight.getTeam1()).thenReturn(team);
+        when(drawnUnfinishedFight.getTeam2()).thenReturn(otherTeam);
+        when(drawnUnfinishedFight.getWinner()).thenReturn(null);
+        when(drawnUnfinishedFight.getLevel()).thenReturn(1);
+        when(drawnUnfinishedFight.isOver()).thenReturn(false);
+        when(drawnUnfinishedFight.isDrawFight()).thenReturn(true);
+        when(drawnUnfinishedFight.getWonDuels(team)).thenReturn(0);
+        when(drawnUnfinishedFight.getDrawDuels(team)).thenReturn(1);
+        when(drawnUnfinishedFight.getScore(team)).thenReturn(2);
+        when(drawnUnfinishedFight.getScoreAgainst(team)).thenReturn(2);
+
+        // Fight finished and drawn.
+        when(drawnFinishedFight.getTeam1()).thenReturn(team);
+        when(drawnFinishedFight.getTeam2()).thenReturn(otherTeam);
+        when(drawnFinishedFight.getWinner()).thenReturn(null);
+        when(drawnFinishedFight.getLevel()).thenReturn(3);
+        when(drawnFinishedFight.isOver()).thenReturn(true);
+        when(drawnFinishedFight.isDrawFight()).thenReturn(true);
+        when(drawnFinishedFight.getWonDuels(team)).thenReturn(0);
+        when(drawnFinishedFight.getDrawDuels(team)).thenReturn(1);
+        when(drawnFinishedFight.getScore(team)).thenReturn(1);
+        when(drawnFinishedFight.getScoreAgainst(team)).thenReturn(1);
+
+        when(wonUntieDuel.getCompetitor1()).thenReturn(competitor1);
+        when(wonUntieDuel.getWinner()).thenReturn(-1);
+
+        when(lostUntieDuel.getCompetitor1()).thenReturn(competitor2);
+        when(lostUntieDuel.getCompetitor2()).thenReturn(competitor2);
+        when(lostUntieDuel.getWinner()).thenReturn(1);
+    }
+
+    @Test
+    public void constructor_expectFullScoreComputed() {
+        final List<Fight> fights = List.of(wonFight, drawnUnfinishedFight, drawnFinishedFight);
+        final List<Duel> unties = List.of(wonUntieDuel);
+
+        final ScoreOfTeam score = new ScoreOfTeam(team, fights, unties);
+
+        assertEquals(score.getTeam(), team);
+        assertEquals(score.getTournament(), tournament);
+        assertEquals(score.getWonFights().intValue(), 1);
+        assertEquals(score.getDrawFights().intValue(), 1);
+        assertEquals(score.getFightsDone().intValue(), 3);
+        assertEquals(score.getWonDuels().intValue(), 1);
+        assertEquals(score.getDrawDuels().intValue(), 2);
+        assertEquals(score.getHits().intValue(), 8);
+        assertEquals(score.getHitsLost().intValue(), 4);
+        assertEquals(score.getLevel().intValue(), 3);
+        assertEquals(score.getUntieDuels().intValue(), 1);
+    }
+
+    @Test
+    public void setUntieDuels_withCompetitor2Loss_expectNotCounted() {
+        final ScoreOfTeam score = new ScoreOfTeam(team, List.of(wonFight), List.of(lostUntieDuel));
+        assertEquals(score.getUntieDuels().intValue(), 0);
+    }
+
+    @Test
+    public void getTournament_withoutTeam_expectNull() {
+        final ScoreOfTeam score = new ScoreOfTeam();
+        assertEquals(score.getTournament(), null);
+    }
+
+    @Test
+    public void settersAndGetters_expectRoundTrip() {
+        final ScoreOfTeam score = new ScoreOfTeam();
+        score.setSortingIndex(4);
+        score.setSwissTieBreakValue(1.5);
+
+        assertEquals(score.getSortingIndex().intValue(), 4);
+        assertEquals(score.getSwissTieBreakValue(), 1.5);
+    }
+
+    @Test
+    public void toString_expectContainsTeamNameAndCounters() {
+        when(team.getName()).thenReturn("Team A");
+        final ScoreOfTeam score = new ScoreOfTeam(team, List.of(wonFight), List.of(wonUntieDuel));
+
+        final String text = score.toString();
+
+        assertNotNull(text);
+        assertTrue(text.contains("Team A"));
+        assertTrue(text.contains("hits lost:"));
+    }
+}
+
+

--- a/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/tests/csv/CsvReaderTest.java
+++ b/backend/kendo-tournament-core/src/test/java/com/softwaremagico/kt/core/tests/csv/CsvReaderTest.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.Objects;
 
 @SpringBootTest
-@Test
+@Test(groups = "csvReader")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class CsvReaderTest extends AbstractTestNGSpringContextTests {
 

--- a/backend/kendo-tournament-core/src/test/resources/testng.xml
+++ b/backend/kendo-tournament-core/src/test/resources/testng.xml
@@ -77,6 +77,7 @@
                 <include name="participantCsvTests"/>
                 <include name="scoreOfCompetitorCustomTests"/>
                 <include name="namespaceContextImplTests"/>
+                <include name="clubCsvTests"/>
             </run>
         </groups>
         <classes>
@@ -180,6 +181,10 @@
             <class name="com.softwaremagico.kt.core.csv.ParticipantCsvTest"/>
             <class name="com.softwaremagico.kt.core.score.ScoreOfCompetitorCustomTest"/>
             <class name="com.softwaremagico.kt.core.controller.VersionControllerNamespaceContextImplTest"/>
+            <class name="com.softwaremagico.kt.core.pool.BasePoolTest"/>
+            <class name="com.softwaremagico.kt.core.tests.exceptions.CoreExceptionsConstructorsCoverageTest"/>
+            <class name="com.softwaremagico.kt.logger.PoolLoggerTest"/>
+            <class name="com.softwaremagico.kt.core.csv.ClubCsvTest"/>
         </classes>
     </test>
 </suite>

--- a/backend/kendo-tournament-logger/src/test/java/com/softwaremagico/kt/logger/tests/AbstractLoggingTest.java
+++ b/backend/kendo-tournament-logger/src/test/java/com/softwaremagico/kt/logger/tests/AbstractLoggingTest.java
@@ -10,22 +10,24 @@ package com.softwaremagico.kt.logger.tests;
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
 
 import com.softwaremagico.kt.logger.AbstractLogging;
+import ch.qos.logback.classic.Level;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.Signature;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -47,6 +49,7 @@ public class AbstractLoggingTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         logging = new ExposedLogging();
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(ExposedLogging.class)).setLevel(Level.DEBUG);
     }
 
     @Test(groups = "abstractLoggingTests")
@@ -83,6 +86,20 @@ public class AbstractLoggingTest {
         logging.callTimedLog(25L, joinPoint);
     }
 
+    @Test(groups = "abstractLoggingTests")
+    public void shouldLogJoinPointWhenDebugEnabled() {
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getName()).thenReturn("method");
+        when(joinPoint.getTarget()).thenReturn(new LocalTarget());
+
+        logging.callLog(joinPoint, "one", 2);
+    }
+
+    @Test(groups = "abstractLoggingTests")
+    public void shouldLogTemplateMessage() {
+        logging.callLogTemplate("Value: {}", "sample");
+    }
+
     private static final class ExposedLogging extends AbstractLogging {
         public String callLogMessage(JoinPoint joinPoint, Object... args) {
             return logMessage(joinPoint, args);
@@ -94,6 +111,14 @@ public class AbstractLoggingTest {
 
         public void callTimedLog(long millis, JoinPoint joinPoint, Object... args) {
             log(millis, joinPoint, args);
+        }
+
+        public void callLog(JoinPoint joinPoint, Object... args) {
+            log(joinPoint, args);
+        }
+
+        public void callLogTemplate(String messageTemplate, Object... arguments) {
+            log(messageTemplate, arguments);
         }
     }
 

--- a/backend/kendo-tournament-logger/src/test/java/com/softwaremagico/kt/logger/tests/BasicLoggerTest.java
+++ b/backend/kendo-tournament-logger/src/test/java/com/softwaremagico/kt/logger/tests/BasicLoggerTest.java
@@ -59,6 +59,27 @@ public class BasicLoggerTest {
 	}
 
 	@Test(groups = "basicLoggerTests")
+	@SuppressWarnings("java:S6068")
+	public void shouldSanitizeWarningWithoutClassName() {
+		when(this.logger.isWarnEnabled()).thenReturn(true);
+
+		BasicLogger.warning(this.logger, "line\n{}", new Object[]{"a\tb"});
+
+		final ArgumentCaptor<Object[]> argsCaptor = ArgumentCaptor.forClass(Object[].class);
+		verify(this.logger).warn(eq("line_{}"), argsCaptor.capture());
+		assertEquals(argsCaptor.getValue()[0], "a_b");
+	}
+
+	@Test(groups = "basicLoggerTests")
+	public void shouldNotLogWarningWithoutClassNameWhenDisabled() {
+		when(this.logger.isWarnEnabled()).thenReturn(false);
+
+		BasicLogger.warning(this.logger, "msg", "x");
+
+		verify(this.logger, never()).warn(anyString(), any(Object[].class));
+	}
+
+	@Test(groups = "basicLoggerTests")
 	public void shouldNotLogWarningWhenDisabled() {
 		when(this.logger.isWarnEnabled()).thenReturn(false);
 
@@ -89,6 +110,27 @@ public class BasicLoggerTest {
 	}
 
 	@Test(groups = "basicLoggerTests")
+	@SuppressWarnings("java:S6068")
+	public void shouldSanitizeDebugWithoutClassName() {
+		when(this.logger.isDebugEnabled()).thenReturn(true);
+
+		BasicLogger.debug(this.logger, "d\tebug {}", new Object[]{"v\n1"});
+
+		final ArgumentCaptor<Object[]> argsCaptor = ArgumentCaptor.forClass(Object[].class);
+		verify(this.logger).debug(eq("d_ebug {}"), argsCaptor.capture());
+		assertEquals(argsCaptor.getValue()[0], "v_1");
+	}
+
+	@Test(groups = "basicLoggerTests")
+	public void shouldNotLogDebugWithoutClassNameWhenDisabled() {
+		when(this.logger.isDebugEnabled()).thenReturn(false);
+
+		BasicLogger.debug(this.logger, "msg", "x");
+
+		verify(this.logger, never()).debug(anyString(), any(Object[].class));
+	}
+
+	@Test(groups = "basicLoggerTests")
 	public void shouldLogSevereWithClassPrefix() {
 		when(this.logger.isErrorEnabled()).thenReturn(true);
 
@@ -105,6 +147,51 @@ public class BasicLoggerTest {
 		BasicLogger.errorMessageNotification(this.logger, "Clazz", throwable);
 
 		verify(this.logger).error("Exception on class {}:\n", "Clazz", throwable);
+	}
+
+	@Test(groups = "basicLoggerTests")
+	public void shouldNotifyErrorWithClassNameWhenEnabled() {
+		when(this.logger.isErrorEnabled()).thenReturn(true);
+
+		BasicLogger.errorMessageNotification(this.logger, "Clazz", "boom {}", "x");
+
+		verify(this.logger).error(eq("Clazz: boom {}"), any(Object[].class));
+	}
+
+	@Test(groups = "basicLoggerTests")
+	public void shouldNotNotifyErrorWithClassNameWhenDisabled() {
+		when(this.logger.isErrorEnabled()).thenReturn(false);
+
+		BasicLogger.errorMessageNotification(this.logger, "Clazz", "boom {}", "x");
+
+		verify(this.logger, never()).error(anyString(), any(Object[].class));
+	}
+
+	@Test(groups = "basicLoggerTests")
+	public void shouldNotifyErrorWithoutClassNameWhenEnabled() {
+		when(this.logger.isErrorEnabled()).thenReturn(true);
+
+		BasicLogger.errorMessageNotification(this.logger, "boom {}", new Object[]{"x"});
+
+		verify(this.logger).error(eq("boom {}"), any(Object[].class));
+	}
+
+	@Test(groups = "basicLoggerTests")
+	public void shouldNotNotifyErrorWithoutClassNameWhenDisabled() {
+		when(this.logger.isErrorEnabled()).thenReturn(false);
+
+		BasicLogger.errorMessageNotification(this.logger, "boom {}", new Object[]{"x"});
+
+		verify(this.logger, never()).error(anyString(), any(Object[].class));
+	}
+
+	@Test(groups = "basicLoggerTests")
+	public void shouldNotNotifyThrowableWhenDisabled() {
+		when(this.logger.isErrorEnabled()).thenReturn(false);
+
+		BasicLogger.errorMessageNotification(this.logger, "Clazz", new IllegalStateException("bad"));
+
+		verify(this.logger, never()).error(anyString(), any(), any());
 	}
 
 	@Test(groups = "basicLoggerTests")

--- a/backend/kendo-tournament-logger/src/test/java/com/softwaremagico/kt/logger/tests/RestAccessLoggingTest.java
+++ b/backend/kendo-tournament-logger/src/test/java/com/softwaremagico/kt/logger/tests/RestAccessLoggingTest.java
@@ -21,8 +21,9 @@ package com.softwaremagico.kt.logger.tests;
  * #L%
  */
 
-import com.softwaremagico.kt.logger.BasicLogging;
 import ch.qos.logback.classic.Level;
+import com.softwaremagico.kt.logger.RestAccessLogging;
+import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
 import org.mockito.Mock;
@@ -37,9 +38,9 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
-public class BasicLoggingTest {
+public class RestAccessLoggingTest {
 
-    private BasicLogging basicLogging;
+    private RestAccessLogging restAccessLogging;
 
     @Mock
     private ProceedingJoinPoint joinPoint;
@@ -50,11 +51,11 @@ public class BasicLoggingTest {
     @BeforeMethod(alwaysRun = true)
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        basicLogging = new BasicLogging();
-        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(BasicLogging.class)).setLevel(Level.DEBUG);
+        restAccessLogging = new RestAccessLogging();
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(RestAccessLogging.class)).setLevel(Level.DEBUG);
     }
 
-    @Test(groups = "basicLoggingTests")
+    @Test(groups = "restAccessLoggingTests")
     public void shouldExecuteAroundAndReturnValue() throws Throwable {
         when(joinPoint.getSignature()).thenReturn(signature);
         when(signature.getName()).thenReturn("method");
@@ -62,13 +63,13 @@ public class BasicLoggingTest {
         when(joinPoint.getArgs()).thenReturn(new Object[0]);
         when(joinPoint.proceed()).thenReturn("ok");
 
-        Object result = basicLogging.logAround(joinPoint);
+        Object result = restAccessLogging.logAround(joinPoint);
 
         assertEquals(result, "ok");
         verify(joinPoint, times(1)).proceed();
     }
 
-    @Test(groups = "basicLoggingTests")
+    @Test(groups = "restAccessLoggingTests")
     public void shouldHandleNullReturnValue() throws Throwable {
         when(joinPoint.getSignature()).thenReturn(signature);
         when(signature.getName()).thenReturn("method");
@@ -76,34 +77,28 @@ public class BasicLoggingTest {
         when(joinPoint.getArgs()).thenReturn(new Object[0]);
         when(joinPoint.proceed()).thenReturn(null);
 
-        Object result = basicLogging.logAround(joinPoint);
+        Object result = restAccessLogging.logAround(joinPoint);
 
         assertNull(result);
         verify(joinPoint, times(1)).proceed();
     }
 
-
-    @Test(groups = "basicLoggingTests")
+    @Test(groups = "restAccessLoggingTests")
     public void shouldAcceptBeforeAndAfterAdviceCalls() {
-        basicLogging.beforeAdvice(joinPoint);
-        basicLogging.afterAdvice();
+        final JoinPoint before = joinPoint;
+        restAccessLogging.beforeAdvice(before);
+        restAccessLogging.afterAdvice();
     }
 
-    @Test(groups = "basicLoggingTests")
+    @Test(groups = "restAccessLoggingTests")
     public void shouldAcceptAfterReturningAdviceForBothBranches() {
-        basicLogging.afterReturningAdvice("value");
-        basicLogging.afterReturningAdvice(null);
+        restAccessLogging.afterReturningAdvice("value");
+        restAccessLogging.afterReturningAdvice(null);
     }
 
-    @Test(groups = "basicLoggingTests")
+    @Test(groups = "restAccessLoggingTests")
     public void shouldAcceptAfterThrowingAdvice() {
-        basicLogging.afterThrowingAdvice(new IllegalArgumentException("bad input"));
+        restAccessLogging.afterThrowingAdvice(new IllegalArgumentException("bad input"));
     }
 }
-
-
-
-
-
-
 

--- a/backend/kendo-tournament-logger/src/test/resources/testng.xml
+++ b/backend/kendo-tournament-logger/src/test/resources/testng.xml
@@ -15,6 +15,7 @@
                 <include name="kendoTournamentLoggerTests"/>
                 <include name="basicLoggingTests"/>
                 <include name="loggerAdaptersTests"/>
+                <include name="restAccessLoggingTests"/>
             </run>
         </groups>
         <classes>
@@ -25,6 +26,7 @@
             <class name="com.softwaremagico.kt.logger.tests.BasicLoggingTest"/>
             <class name="com.softwaremagico.kt.logger.tests.LoggerAdaptersCoverageTest"/>
             <class name="com.softwaremagico.kt.logger.tests.LoggerAnnotationsCoverageTest"/>
+            <class name="com.softwaremagico.kt.logger.tests.RestAccessLoggingTest"/>
         </classes>
     </test>
 </suite>

--- a/backend/kendo-tournament-pdf/src/test/java/com/softwaremagico/kt/pdf/lists/EmptyFightsListTest.java
+++ b/backend/kendo-tournament-pdf/src/test/java/com/softwaremagico/kt/pdf/lists/EmptyFightsListTest.java
@@ -1,0 +1,69 @@
+package com.softwaremagico.kt.pdf.lists;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (PDF)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.controller.models.FightDTO;
+import com.softwaremagico.kt.core.controller.models.TournamentDTO;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.awt.Color;
+import java.util.Collections;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+
+@Test(groups = "emptyFightsListTests")
+public class EmptyFightsListTest {
+
+    private EmptyFightsList emptyFightsList;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        this.emptyFightsList = new EmptyFightsList(null, Locale.getDefault(), new TournamentDTO(), Collections.emptyList(), 0);
+    }
+
+    @Test
+    public void shouldUseBlackCellBorderColor() {
+        assertEquals(this.emptyFightsList.getCellBorderColor(), Color.BLACK);
+    }
+
+    @Test
+    public void shouldReturnEmptyDrawFight() {
+        assertEquals(this.emptyFightsList.getDrawFight(new FightDTO(), 0), "");
+    }
+
+    @Test
+    public void shouldReturnNoFaults() {
+        assertFalse(this.emptyFightsList.getFaults(new FightDTO(), 0, true));
+        assertFalse(this.emptyFightsList.getFaults(new FightDTO(), 0, false));
+    }
+
+    @Test
+    public void shouldReturnNullScore() {
+        assertNull(this.emptyFightsList.getScore(new FightDTO(), 0, 0, true));
+    }
+}
+
+

--- a/backend/kendo-tournament-pdf/src/test/resources/testng.xml
+++ b/backend/kendo-tournament-pdf/src/test/resources/testng.xml
@@ -15,6 +15,7 @@
                  <include name="diplomaPdf"/>
                  <include name="qrPdf"/>
                  <include name="blogTests"/>
+                 <include name="emptyFightsListTests"/>
              </run>
          </groups>
          <classes>
@@ -27,6 +28,7 @@
              <class name="com.softwaremagico.kt.pdf.QrTests"/>
              <class name="com.softwaremagico.kt.html.HtmlTests"/>
              <class name="com.softwaremagico.kt.html.controller.ZipControllerTest"/>
+             <class name="com.softwaremagico.kt.pdf.lists.EmptyFightsListTest"/>
          </classes>
      </test>
 </suite>

--- a/backend/kendo-tournament-persistence/src/main/java/com/softwaremagico/kt/persistence/entities/Element.java
+++ b/backend/kendo-tournament-persistence/src/main/java/com/softwaremagico/kt/persistence/entities/Element.java
@@ -169,8 +169,9 @@ public abstract class Element implements Serializable {
     }
 
     /**
-     * Two entities are considered equal when they share the same database primary key.
-     * A {@code null} ID (transient entity) is never equal to another entity.
+     * Two entities are considered equal when they share the same non-null database primary key.
+     * A {@code null} ID (transient/unsaved entity) is never equal to another entity, even if the
+     * other entity is also transient, unless it is the very same instance ({@code this == o}).
      */
     @Override
     public boolean equals(Object o) {
@@ -181,6 +182,9 @@ public abstract class Element implements Serializable {
             return false;
         }
         final Element element = (Element) o;
+        if (id == null || element.id == null) {
+            return false;
+        }
         return Objects.equals(id, element.id);
     }
 

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/encryption/BCryptPasswordConverterTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/encryption/BCryptPasswordConverterTest.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 @SuppressWarnings("unused")
-@Test
+@Test(groups = "cryptoConverters")
 class BCryptPasswordConverterTest {
 
     @Test

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/encryption/EncryptedRoundTripCryptoConvertersTests.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/encryption/EncryptedRoundTripCryptoConvertersTests.java
@@ -1,0 +1,158 @@
+package com.softwaremagico.kt.persistence.encryption;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Persistence)
+ * %%
+ * Copyright (C) 2021 - 2026 SoftwareMagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.persistence.values.AchievementGrade;
+import com.softwaremagico.kt.persistence.values.AchievementType;
+import com.softwaremagico.kt.persistence.values.ImageCompression;
+import com.softwaremagico.kt.persistence.values.ImageFormat;
+import com.softwaremagico.kt.persistence.values.RoleType;
+import com.softwaremagico.kt.persistence.values.TournamentExtraPropertyKey;
+import com.softwaremagico.kt.persistence.values.TournamentImageType;
+import com.softwaremagico.kt.persistence.values.TournamentType;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Exercises the real encryption/decryption path (with a non-empty key configured)
+ * for the enum, {@link LongCryptoConverter} and {@link ByteArrayCryptoConverter}
+ * converters, which are otherwise only tested through the "plain" (no-key) path.
+ */
+@Test(groups = "cryptoConverters")
+public class EncryptedRoundTripCryptoConvertersTests {
+
+    private static final String ENCRYPTION_CODE = "encryptedRoundTripKey";
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() {
+        KeyProperty.configure(ENCRYPTION_CODE, null, null);
+    }
+
+    @Test
+    public void shouldRoundTripTournamentTypeWithEncryption() {
+        assertEncryptedRoundTrip(new TournamentTypeCryptoConverter(), TournamentType.LEAGUE);
+    }
+
+    @Test
+    public void shouldRoundTripRoleTypeWithEncryption() {
+        assertEncryptedRoundTrip(new RoleTypeCryptoConverter(), RoleType.COMPETITOR);
+    }
+
+    @Test
+    public void shouldRoundTripAchievementTypeWithEncryption() {
+        assertEncryptedRoundTrip(new AchievementTypeCryptoConverter(), AchievementType.THE_WINNER);
+    }
+
+    @Test
+    public void shouldRoundTripAchievementGradeWithEncryption() {
+        assertEncryptedRoundTrip(new AchievementGradeCryptoConverter(), AchievementGrade.SILVER);
+    }
+
+    @Test
+    public void shouldRoundTripTournamentImageTypeWithEncryption() {
+        assertEncryptedRoundTrip(new TournamentImageTypeCryptoConverter(), TournamentImageType.BANNER);
+    }
+
+    @Test
+    public void shouldRoundTripImageCompressionWithEncryption() {
+        assertEncryptedRoundTrip(new ImageCompressionCryptoConverter(), ImageCompression.JPG);
+    }
+
+    @Test
+    public void shouldRoundTripImageFormatWithEncryption() {
+        assertEncryptedRoundTrip(new ImageFormatCryptoConverter(), ImageFormat.SVG);
+    }
+
+    @Test
+    public void shouldRoundTripTournamentExtraPropertyKeyWithEncryption() {
+        assertEncryptedRoundTrip(new TournamentExtraPropertyKeyTypeCryptoConverter(),
+                TournamentExtraPropertyKey.NUMBER_OF_WINNERS);
+    }
+
+    @Test
+    public void shouldRoundTripLongValuesWithEncryption() {
+        final LongCryptoConverter converter = new LongCryptoConverter();
+        final Long value = 987654321L;
+
+        final String encrypted = converter.convertToDatabaseColumn(value);
+        final Long decrypted = converter.convertToEntityAttribute(encrypted);
+
+        Assert.assertNotNull(encrypted);
+        Assert.assertNotEquals(encrypted, value.toString());
+        Assert.assertEquals(decrypted, value);
+    }
+
+    @Test
+    public void shouldReturnNullForInvalidEncryptedLong() {
+        final LongCryptoConverter converter = new LongCryptoConverter();
+
+        Assert.assertNull(converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void shouldReturnNullForNonNumericDecryptedLong() {
+        final LongCryptoConverter converter = new LongCryptoConverter();
+        // Encrypt a non-numeric string so that decryption succeeds but parsing fails.
+        final String encryptedGarbage = new StringCryptoConverter().convertToDatabaseColumn("not-a-long");
+
+        Assert.assertNull(converter.convertToEntityAttribute(encryptedGarbage));
+    }
+
+    @Test
+    public void shouldRoundTripByteArrayValuesWithEncryption() {
+        final ByteArrayCryptoConverter converter = new ByteArrayCryptoConverter();
+        final byte[] value = "sensitive-bytes".getBytes(StandardCharsets.UTF_8);
+
+        final String encrypted = converter.convertToDatabaseColumn(value);
+        final byte[] decrypted = converter.convertToEntityAttribute(encrypted);
+
+        Assert.assertNotNull(encrypted);
+        Assert.assertEquals(decrypted, value);
+    }
+
+    @Test
+    public void shouldNotEncryptEmptyOrNullByteArray() {
+        final ByteArrayCryptoConverter converter = new ByteArrayCryptoConverter();
+
+        // An empty array is not encrypted (isNotNullOrEmpty == false), only base64-encoded as-is.
+        Assert.assertEquals(converter.convertToDatabaseColumn(new byte[0]), "");
+        Assert.assertNull(converter.convertToDatabaseColumn(null));
+    }
+
+    private <E> void assertEncryptedRoundTrip(AbstractCryptoConverter<E> converter, E value) {
+        final String encrypted = converter.convertToDatabaseColumn(value);
+        final E decrypted = converter.convertToEntityAttribute(encrypted);
+
+        Assert.assertNotNull(encrypted);
+        Assert.assertNotEquals(encrypted, value.toString());
+        Assert.assertEquals(decrypted, value);
+
+        // Invalid/decrypted-garbage input must not blow up, only return null.
+        final String garbage = new StringCryptoConverter().convertToDatabaseColumn("__not_a_valid_enum_value__");
+        Assert.assertNull(converter.convertToEntityAttribute(garbage));
+    }
+}
+
+

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/AuthenticatedUserTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/AuthenticatedUserTest.java
@@ -1,0 +1,171 @@
+package com.softwaremagico.kt.persistence.entities;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Persistence)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import org.springframework.security.core.GrantedAuthority;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "authenticatedUserEntity")
+public class AuthenticatedUserTest {
+
+    @Test
+    public void constructor_withUsername_expectUsernameAndHashSet() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        assertEquals(user.getUsername(), "john");
+        assertEquals(user.getUsernameHash(), "john");
+    }
+
+    @Test
+    public void accountFlags_expectAllTrue() {
+        final AuthenticatedUser user = new AuthenticatedUser();
+        assertTrue(user.isAccountNonExpired());
+        assertTrue(user.isAccountNonLocked());
+        assertTrue(user.isCredentialsNonExpired());
+        assertTrue(user.isEnabled());
+    }
+
+    @Test
+    public void getMobilePhone_expectAlwaysNull() {
+        final AuthenticatedUser user = new AuthenticatedUser();
+        assertNull(user.getMobilePhone());
+    }
+
+    @Test
+    public void getAuthorities_withValidRoles_expectMappedAuthorities() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        user.setRoles(Set.of("ADMIN"));
+
+        final Set<? extends GrantedAuthority> authorities = (Set<? extends GrantedAuthority>) user.getAuthorities();
+
+        assertEquals(authorities.size(), 1);
+        assertEquals(authorities.iterator().next().getAuthority(), "ADMIN");
+    }
+
+    @Test
+    public void getAuthorities_withUnknownRole_expectEmptyAuthorities() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        user.setRoles(Set.of("NOT_A_ROLE"));
+
+        assertTrue(user.getAuthorities().isEmpty());
+    }
+
+    @Test
+    public void getAuthorities_withNullRoles_expectEmptyAuthorities() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        assertTrue(user.getAuthorities().isEmpty());
+    }
+
+    @Test
+    public void getAuthorities_calledTwice_expectCachedResult() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        user.setRoles(Set.of("VIEWER"));
+
+        final Object first = user.getAuthorities();
+        final Object second = user.getAuthorities();
+
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void toString_expectContainsUsernameAndRoles() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        user.setName("John");
+        user.setLastname("Doe");
+        user.setRoles(Set.of("ADMIN"));
+
+        final String text = user.toString();
+
+        assertTrue(text.contains("john"));
+        assertTrue(text.contains("John"));
+        assertTrue(text.contains("Doe"));
+    }
+
+    @Test
+    public void equals_withSameIdAndSameFields_expectTrue() {
+        final AuthenticatedUser user1 = new AuthenticatedUser("john");
+        user1.setId(1);
+        final AuthenticatedUser user2 = new AuthenticatedUser("john");
+        user2.setId(1);
+
+        assertEquals(user1, user2);
+        assertEquals(user1.hashCode(), user2.hashCode());
+    }
+
+    @Test
+    public void equals_withSameIdButDifferentUsername_expectFalse() {
+        final AuthenticatedUser user1 = new AuthenticatedUser("john");
+        user1.setId(1);
+        final AuthenticatedUser user2 = new AuthenticatedUser("jane");
+        user2.setId(1);
+
+        // Element#equals() only compares the primary key, but AuthenticatedUser overrides equals()
+        // to also require the mutable fields to match, since two persisted rows sharing an id would
+        // be a data corruption bug that should never be masked by equals().
+        assertNotEquals(user1, user2);
+    }
+
+    @Test
+    public void equals_withDifferentTransientFields_expectFalse() {
+        final AuthenticatedUser user1 = new AuthenticatedUser("john");
+        final AuthenticatedUser user2 = new AuthenticatedUser("jane");
+
+        assertNotEquals(user1, user2);
+    }
+
+    @Test
+    public void equals_withSameFieldsButNoId_expectFalseSinceBothTransient() {
+        final AuthenticatedUser user1 = new AuthenticatedUser("john");
+        final AuthenticatedUser user2 = new AuthenticatedUser("john");
+
+        // Two distinct transient entities are never equal, even with identical field values,
+        // because Element.equals requires a non-null shared id.
+        assertNotEquals(user1, user2);
+    }
+
+    @Test
+    public void equals_withNull_expectFalse() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        assertFalse(user.equals(null));
+    }
+
+    @Test
+    public void equals_withDifferentClass_expectFalse() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        assertFalse(user.equals("not-a-user"));
+    }
+
+    @Test
+    public void equals_withItself_expectTrue() {
+        final AuthenticatedUser user = new AuthenticatedUser("john");
+        assertEquals(user, user);
+    }
+}
+
+

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/ClubTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/ClubTest.java
@@ -1,0 +1,131 @@
+package com.softwaremagico.kt.persistence.entities;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Persistence)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "clubEntity")
+public class ClubTest {
+
+    @Test
+    public void constructor_expectFieldsSetWithCaseNormalization() {
+        final Club club = new Club("john's DOJO", "spain", "madrid");
+
+        assertEquals(club.getName(), "John's Dojo");
+        assertEquals(club.getCountry(), "Spain");
+        assertEquals(club.getCity(), "Madrid");
+        assertEquals(club.toString(), "John's Dojo");
+    }
+
+    @Test
+    public void setRepresentative_withThreeArguments_expectAllFieldsSet() {
+        final Club club = new Club("Dojo", "Spain", "Madrid");
+        club.setRepresentative("ID1", "mail@example.com", "123456789");
+
+        assertEquals(club.getRepresentativeId(), "ID1");
+        assertEquals(club.getEmail(), "mail@example.com");
+        assertEquals(club.getPhone(), "123456789");
+    }
+
+    @Test
+    public void setRepresentative_withSingleArgument_expectOnlyIdSet() {
+        final Club club = new Club("Dojo", "Spain", "Madrid");
+        club.setRepresentative("ID2");
+
+        assertEquals(club.getRepresentativeId(), "ID2");
+    }
+
+    @Test
+    public void storeWeb_expectTrimmedValue() {
+        final Club club = new Club("Dojo", "Spain", "Madrid");
+        club.storeWeb("  https://example.com  ");
+
+        assertEquals(club.getWeb(), "https://example.com");
+    }
+
+    @Test
+    public void mailAccessors_expectDelegateToEmail() {
+        final Club club = new Club("Dojo", "Spain", "Madrid");
+        club.setMail("contact@example.com");
+
+        assertEquals(club.getMail(), "contact@example.com");
+        assertEquals(club.getEmail(), "contact@example.com");
+    }
+
+    @Test
+    public void addressSetter_expectCaseNormalized() {
+        final Club club = new Club("Dojo", "Spain", "Madrid");
+        club.setAddress("MAIN street 12");
+
+        assertEquals(club.getAddress(), "Main Street 12");
+    }
+
+    @Test
+    public void compareTo_byNameThenCity_expectOrderedResult() {
+        final Club alpha = new Club("Alpha", "Spain", "Madrid");
+        final Club beta = new Club("Beta", "Spain", "Madrid");
+
+        assertTrue(alpha.compareTo(beta) < 0);
+        assertTrue(beta.compareTo(alpha) > 0);
+    }
+
+    @Test
+    public void compareTo_ignoringCase_expectEqualOrdering() {
+        final Club lower = new Club("kendo", "Spain", "alcala");
+        final Club upper = new Club("KENDO", "Spain", "ALCALA");
+
+        // Club names/cities go through StringUtils.setCase() (title-case) on assignment,
+        // so this mainly verifies the Collator SECONDARY strength ignores residual case differences.
+        assertEquals(lower.compareTo(upper), 0);
+    }
+
+    @Test
+    public void equals_delegatesToElementEquals() {
+        final Club club1 = new Club("Dojo", "Spain", "Madrid");
+        club1.setId(1);
+        final Club club2 = new Club("Other", "France", "Paris");
+        club2.setId(1);
+
+        assertEquals(club1, club2);
+        assertEquals(club1.hashCode(), club2.hashCode());
+    }
+
+    @Test
+    public void equals_withDistinctTransientInstances_expectFalse() {
+        final Club club1 = new Club("Dojo", "Spain", "Madrid");
+        final Club club2 = new Club("Dojo", "Spain", "Madrid");
+
+        assertNotEquals(club1, club2);
+    }
+
+    @Test
+    public void equals_withNull_expectFalse() {
+        final Club club = new Club("Dojo", "Spain", "Madrid");
+        assertFalse(club.equals(null));
+    }
+}
+

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/EntityEqualsCoverageTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/EntityEqualsCoverageTest.java
@@ -70,10 +70,19 @@ public class EntityEqualsCoverageTest {
     }
 
     @Test
-    public void when_equalsBothNullId_expect_true() {
+    public void when_equalsBothNullId_expect_false() {
+        // Two distinct transient (unsaved) entities must never be considered equal,
+        // otherwise all "new" instances of the same class would collapse into a single
+        // logical value (e.g. in Sets/Lists) before being persisted.
         final Club club1 = new Club();
         final Club club2 = new Club();
-        assertThat(club1.equals(club2)).isTrue();
+        assertThat(club1.equals(club2)).isFalse();
+    }
+
+    @Test
+    public void when_equalsBothNullIdSameInstance_expect_true() {
+        final Club club = new Club();
+        assertThat(club.equals(club)).isTrue();
     }
 
     @Test

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/FightEntityCoverageTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/FightEntityCoverageTest.java
@@ -1,0 +1,220 @@
+package com.softwaremagico.kt.persistence.entities;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Persistence)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.persistence.values.Score;
+import com.softwaremagico.kt.persistence.values.TournamentType;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "fightEntity")
+public class FightEntityCoverageTest {
+
+    private Tournament tournament;
+    private Team team1;
+    private Team team2;
+    private Participant competitor1;
+    private Participant competitor2;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        this.tournament = new Tournament("Fight Entity Tournament", 1, 1, TournamentType.LEAGUE, "tester");
+        this.team1 = new Team("Team1", this.tournament);
+        this.team2 = new Team("Team2", this.tournament);
+        this.competitor1 = new Participant("ID1", "Name1", "Lastname1", null);
+        this.competitor2 = new Participant("ID2", "Name2", "Lastname2", null);
+        this.team1.addMember(this.competitor1);
+        this.team2.addMember(this.competitor2);
+    }
+
+    private Fight newFight() {
+        return new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+    }
+
+    private Duel newDuel(int team1Points, int team2Points) {
+        final Duel duel = new Duel(this.competitor1, this.competitor2, this.tournament, "tester");
+        for (int i = 0; i < team1Points; i++) {
+            duel.addCompetitor1Score(Score.MEN);
+        }
+        for (int i = 0; i < team2Points; i++) {
+            duel.addCompetitor2Score(Score.MEN);
+        }
+        duel.setFinished(true);
+        return duel;
+    }
+
+    @Test
+    public void shouldGenerateDuelsOnConstruction() {
+        final Fight fight = this.newFight();
+
+        assertEquals(fight.getDuels().size(), 1);
+        assertEquals(fight.getTeam1(), this.team1);
+        assertEquals(fight.getTeam2(), this.team2);
+    }
+
+    @Test
+    public void shouldNotGenerateDuelsWhenTeamsAreNull() {
+        final Fight fight = new Fight();
+        fight.setTournament(this.tournament);
+        fight.generateDuels("tester");
+
+        assertTrue(fight.getDuels().isEmpty());
+    }
+
+    @Test
+    public void shouldReturnDuelsOfCompetitor() {
+        final Fight fight = this.newFight();
+
+        assertEquals(fight.getDuels(this.competitor1).size(), 1);
+        assertTrue(fight.getDuels(new Participant("OTHER", "X", "Y", null)).isEmpty());
+    }
+
+    @Test
+    public void shouldDeclareTeam1WinnerByDuelCount() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(2, 0))));
+
+        assertEquals(fight.getWinner(), this.team1);
+        assertEquals(fight.getLoser(), this.team2);
+        assertFalse(fight.isDrawFight());
+        assertTrue(fight.isWon(this.competitor1));
+        assertFalse(fight.isWon(this.competitor2));
+    }
+
+    @Test
+    public void shouldDeclareTeam2WinnerByDuelCount() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(0, 2))));
+
+        assertEquals(fight.getWinner(), this.team2);
+        assertEquals(fight.getLoser(), this.team1);
+        assertTrue(fight.isWon(this.competitor2));
+    }
+
+    @Test
+    public void shouldDeclareTeam1WinnerByPointsWhenDuelsTied() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(2, 0), this.newDuel(0, 1))));
+
+        assertEquals(fight.getWinner(), this.team1);
+    }
+
+    @Test
+    public void shouldDeclareTeam2WinnerByPointsWhenDuelsTied() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(0, 3), this.newDuel(1, 0))));
+
+        assertEquals(fight.getWinner(), this.team2);
+    }
+
+    @Test
+    public void shouldBeDrawWhenEverythingIsTied() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(1, 1))));
+
+        assertNull(fight.getWinner());
+        assertNull(fight.getLoser());
+        assertTrue(fight.isDrawFight());
+        assertFalse(fight.isWon(this.competitor1));
+        assertFalse(fight.isWon(null));
+    }
+
+    @Test
+    public void shouldBeOverWhenAllDuelsAreFinished() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(2, 0))));
+
+        assertTrue(fight.isOver());
+        assertTrue(fight.toString().contains("[F]"));
+    }
+
+    @Test
+    public void shouldNotBeOverWhenDuelUnfinished() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        final Duel duel = new Duel(this.competitor1, this.competitor2, this.tournament, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(duel)));
+
+        assertFalse(fight.isOver());
+        assertFalse(fight.toString().contains("[F]"));
+    }
+
+    @Test
+    public void shouldComputeScoreAndScoreAgainstForCompetitor() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(2, 1))));
+
+        assertEquals(fight.getScore(this.competitor1), Integer.valueOf(2));
+        assertEquals(fight.getScoreAgainst(this.competitor1), Integer.valueOf(1));
+        assertEquals(fight.getScore(this.competitor2), Integer.valueOf(1));
+        assertEquals(fight.getScoreAgainst(this.competitor2), Integer.valueOf(2));
+    }
+
+    @Test
+    public void shouldComputeScoreAndScoreAgainstForTeams() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(2, 1))));
+
+        assertEquals(fight.getScore(this.team1), Integer.valueOf(2));
+        assertEquals(fight.getScore(this.team2), Integer.valueOf(1));
+        assertEquals(fight.getScoreAgainst(this.team1), Integer.valueOf(1));
+        assertEquals(fight.getScoreAgainst(this.team2), Integer.valueOf(2));
+        assertEquals(fight.getScoreTeam1(), Integer.valueOf(2));
+        assertEquals(fight.getScoreTeam2(), Integer.valueOf(1));
+
+        final Team unrelatedTeam = new Team("Unrelated", this.tournament);
+        assertEquals(fight.getScore(unrelatedTeam), Integer.valueOf(0));
+        assertEquals(fight.getScoreAgainst(unrelatedTeam), Integer.valueOf(0));
+    }
+
+    @Test
+    public void shouldCountDrawDuelsForCompetitorAndTeam() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(1, 1), this.newDuel(2, 0))));
+
+        assertEquals(fight.getDrawDuels(this.competitor1), Integer.valueOf(1));
+        assertEquals(fight.getDrawDuels(this.team1), Integer.valueOf(1));
+        assertEquals(fight.getDrawDuels(this.team2), Integer.valueOf(1));
+
+        final Team unrelatedTeam = new Team("Unrelated2", this.tournament);
+        assertEquals(fight.getDrawDuels(unrelatedTeam), Integer.valueOf(0));
+    }
+
+    @Test
+    public void shouldCountDuelsWonAndWonDuelsPerTeam() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.setDuels(new java.util.ArrayList<>(java.util.List.of(this.newDuel(2, 0), this.newDuel(0, 1))));
+
+        assertEquals(fight.getDuelsWon(this.competitor1), Integer.valueOf(1));
+        assertEquals(fight.getDuelsWon(this.competitor2), Integer.valueOf(1));
+        assertEquals(fight.getWonDuels(this.team1), 1);
+        assertEquals(fight.getWonDuels(this.team2), 1);
+
+        final Team unrelatedTeam = new Team("Unrelated3", this.tournament);
+        assertEquals(fight.getWonDuels(unrelatedTeam), 0);
+    }
+}
+

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/GroupEntityCoverageTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/GroupEntityCoverageTest.java
@@ -1,0 +1,143 @@
+package com.softwaremagico.kt.persistence.entities;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Persistence)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.persistence.values.TournamentType;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "groupEntity")
+public class GroupEntityCoverageTest {
+
+    private Tournament tournament;
+    private Team team1;
+    private Team team2;
+    private Participant participant1;
+    private Participant participant2;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        this.tournament = new Tournament("Group Entity Tournament", 1, 1, TournamentType.LEAGUE, "tester");
+        this.team1 = new Team("Team1", this.tournament);
+        this.team2 = new Team("Team2", this.tournament);
+        this.participant1 = new Participant("ID1", "Name1", "Lastname1", null);
+        this.participant2 = new Participant("ID2", "Name2", "Lastname2", null);
+        this.team1.addMember(this.participant1);
+        this.team2.addMember(this.participant2);
+    }
+
+    @Test
+    public void shouldConsiderEmptyOrNullFightListAsOver() {
+        assertTrue(Group.areFightsOverOrNull(new ArrayList<>()));
+    }
+
+    @Test
+    public void shouldConsiderAllFightsOverWhenEveryFightIsFinished() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.getDuels().forEach(duel -> duel.setFinished(true));
+
+        assertTrue(Group.areFightsOverOrNull(List.of(fight)));
+    }
+
+    @Test
+    public void shouldDetectFightsNotOver() {
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+
+        assertFalse(Group.areFightsOverOrNull(List.of(fight)));
+    }
+
+    @Test
+    public void shouldConsiderGroupOverWhenFewerThanTwoTeams() {
+        final Group group = new Group(this.tournament, 0, 0);
+        group.setTeams(new ArrayList<>(List.of(this.team1)));
+        group.setFights(new ArrayList<>());
+
+        assertTrue(group.areFightsOverOrNull());
+    }
+
+    @Test
+    public void shouldDelegateToFightsWhenEnoughTeams() {
+        final Group group = new Group(this.tournament, 0, 0);
+        group.setTeams(new ArrayList<>(List.of(this.team1, this.team2)));
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        fight.getDuels().forEach(duel -> duel.setFinished(true));
+        group.setFights(new ArrayList<>(List.of(fight)));
+
+        assertTrue(group.areFightsOverOrNull());
+        assertTrue(group.isFightOfGroup(fight));
+    }
+
+    @Test
+    public void shouldReplaceFightsPreservingCollectionReference() {
+        final Group group = new Group(this.tournament, 0, 0);
+        group.setFights(new ArrayList<>());
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+
+        group.setFights(List.of(fight));
+
+        assertEquals(group.getFights().size(), 1);
+        assertTrue(group.isFightOfGroup(fight));
+    }
+
+    @Test
+    public void shouldRemoveTeamsAndFights() {
+        final Group group = new Group(this.tournament, 0, 0);
+        group.setTeams(new ArrayList<>(List.of(this.team1, this.team2)));
+        final Fight fight = new Fight(this.tournament, this.team1, this.team2, 0, 0, "tester");
+        group.setFights(new ArrayList<>(List.of(fight)));
+
+        group.removeTeams();
+        group.removeFights();
+
+        assertTrue(group.getTeams().isEmpty());
+        assertTrue(group.getFights().isEmpty());
+    }
+
+    @Test
+    public void shouldCreateUntieDuelAndAppendToList() {
+        final Group group = new Group(this.tournament, 0, 0);
+
+        group.createUntieDuel(this.participant1, this.participant2, "tester");
+
+        assertEquals(group.getUnties().size(), 1);
+        assertEquals(group.getUnties().get(0).getType(), DuelType.UNDRAW);
+    }
+
+    @Test
+    public void shouldReplaceUntiesPreservingCollectionReference() {
+        final Group group = new Group(this.tournament, 0, 0);
+        group.createUntieDuel(this.participant1, this.participant2, "tester");
+        final List<Duel> newUnties = new ArrayList<>(group.getUnties());
+
+        group.setUnties(newUnties);
+
+        assertEquals(group.getUnties().size(), 1);
+    }
+}
+

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/ParticipantTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/ParticipantTest.java
@@ -1,0 +1,191 @@
+package com.softwaremagico.kt.persistence.entities;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Persistence)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import org.testng.annotations.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "participantEntity")
+public class ParticipantTest {
+
+    @Test
+    public void constructor_expectIdCardNormalizedAndNameCased() {
+        final Participant participant = new Participant("ab-12 34 ", "john", "doe", null);
+
+        assertEquals(participant.getIdCard(), "AB1234");
+        assertEquals(participant.getName(), "John");
+        assertEquals(participant.getLastname(), "Doe");
+    }
+
+    @Test
+    public void isValid_withNameAndIdCard_expectTrue() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        assertTrue(participant.isValid());
+    }
+
+    @Test
+    public void isValid_withoutIdCard_expectFalse() {
+        final Participant participant = new Participant(null, "John", "Doe", null);
+        assertFalse(participant.isValid());
+    }
+
+    @Test
+    public void isValid_withEmptyName_expectFalse() {
+        final Participant participant = new Participant("ID1", "", "Doe", null);
+        assertFalse(participant.isValid());
+    }
+
+    @Test
+    public void compareTo_byLastnameThenName_expectOrdered() {
+        final Participant a = new Participant("ID1", "Ana", "Alpha", null);
+        final Participant b = new Participant("ID2", "Beto", "Beta", null);
+
+        assertTrue(a.compareTo(b) < 0);
+        assertTrue(b.compareTo(a) > 0);
+    }
+
+    @Test
+    public void compareTo_withSameNames_andIds_expectOrderedById() {
+        final Participant a = new Participant("ID1", "Ana", "Alpha", null);
+        a.setId(1);
+        final Participant b = new Participant("ID2", "Ana", "Alpha", null);
+        b.setId(2);
+
+        assertTrue(a.compareTo(b) < 0);
+    }
+
+    @Test
+    public void compareTo_withSameNamesAndNoIds_expectConsistentNonException() {
+        final Participant a = new Participant("ID1", "Ana", "Alpha", null);
+        final Participant b = new Participant("ID2", "Ana", "Alpha", null);
+
+        // No exception, and comparing to itself is always 0 (falls back to identity hash otherwise).
+        assertEquals(Integer.signum(a.compareTo(a)), 0);
+        a.compareTo(b);
+    }
+
+    @Test
+    public void generateTemporalToken_expectTokenAndExpirationSet() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        participant.generateTemporalToken();
+
+        assertNotNull(participant.getTemporalToken());
+        assertTrue(participant.getTemporalTokenExpiration().isAfter(LocalDateTime.now(ZoneId.systemDefault())));
+    }
+
+    @Test
+    public void generateToken_expectTokenAndAccountExpirationSet() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        participant.generateToken();
+
+        assertNotNull(participant.getToken());
+        assertTrue(participant.getAccountExpiration().isAfter(LocalDateTime.now(ZoneId.systemDefault())));
+    }
+
+    @Test
+    public void isAccountNonExpired_withoutToken_expectFalse() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        assertFalse(participant.isAccountNonExpired());
+    }
+
+    @Test
+    public void isAccountNonExpired_withFreshToken_expectTrue() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        participant.generateToken();
+        assertTrue(participant.isAccountNonExpired());
+    }
+
+    @Test
+    public void isCredentialsNonExpired_withoutToken_expectFalse() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        assertFalse(participant.isCredentialsNonExpired());
+    }
+
+    @Test
+    public void accountFlags_expectAlwaysUnlockedAndEnabled() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        assertTrue(participant.isAccountNonLocked());
+        assertTrue(participant.isEnabled());
+    }
+
+    @Test
+    public void getUsername_expectIdNameLastnameConcatenated() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        participant.setId(7);
+
+        assertEquals(participant.getUsername(), "7_John_Doe");
+    }
+
+    @Test
+    public void getPassword_expectDelegatesToToken() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        participant.setToken("abc123");
+
+        assertEquals(participant.getPassword(), "abc123");
+    }
+
+    @Test
+    public void getRoles_expectContainsParticipantRole() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        assertTrue(participant.getRoles().contains(Participant.PARTICIPANT_ROLE));
+    }
+
+    @Test
+    public void getAuthorities_expectParticipantAuthority() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        assertEquals(participant.getAuthorities().size(), 1);
+    }
+
+    @Test
+    public void toString_expectLastnameNameFormat() {
+        final Participant participant = new Participant("ID1", "John", "Doe", null);
+        assertNotNull(participant.toString());
+    }
+
+    @Test
+    public void equals_delegatesToElementIdentity() {
+        final Participant p1 = new Participant("ID1", "John", "Doe", null);
+        p1.setId(1);
+        final Participant p2 = new Participant("ID2", "Jane", "Roe", null);
+        p2.setId(1);
+
+        assertEquals(p1, p2);
+        assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    public void equals_withDistinctTransientInstances_expectFalse() {
+        final Participant p1 = new Participant("ID1", "John", "Doe", null);
+        final Participant p2 = new Participant("ID1", "John", "Doe", null);
+
+        assertNotEquals(p1, p2);
+    }
+}
+

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/TeamEntityCoverageTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/entities/TeamEntityCoverageTest.java
@@ -1,0 +1,182 @@
+package com.softwaremagico.kt.persistence.entities;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Persistence)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.persistence.values.TournamentType;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "teamEntity")
+public class TeamEntityCoverageTest {
+
+    private Tournament tournament;
+    private Participant participant;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        this.tournament = new Tournament("Team Entity Tournament", 1, 1, TournamentType.LEAGUE, "tester");
+        this.participant = new Participant("ID1", "Name1", "Lastname1", null);
+    }
+
+    @Test
+    public void shouldCheckMembership() {
+        final Team team = new Team("Team1", this.tournament);
+        team.addMember(this.participant);
+
+        assertTrue(team.isMember(this.participant));
+        assertFalse(team.isMember(new Participant("OTHER", "X", "Y", null)));
+    }
+
+    @Test
+    public void shouldBeEqualToItself() {
+        final Team team = new Team("Team1", this.tournament);
+        assertEquals(team, team);
+    }
+
+    @Test
+    public void shouldNotBeEqualToNullOrDifferentClass() {
+        final Team team = new Team("Team1", this.tournament);
+        assertNotEquals(team, null);
+        assertNotEquals(team, "not-a-team");
+    }
+
+    @Test
+    public void shouldBeEqualByIdWhenBothPersisted() {
+        final Team team1 = new Team("Team1", this.tournament);
+        team1.setId(1);
+        final Team team2 = new Team("DifferentName", null);
+        team2.setId(1);
+
+        assertEquals(team1, team2);
+        assertEquals(team1.hashCode(), team2.hashCode());
+    }
+
+    @Test
+    public void shouldNotBeEqualByNameWhenNamesDiffer() {
+        final Team team1 = new Team("Team1", this.tournament);
+        final Team team2 = new Team("Team2", this.tournament);
+
+        assertNotEquals(team1, team2);
+    }
+
+    @Test
+    public void shouldBeEqualWhenSameTournamentReference() {
+        final Team team1 = new Team("Team1", this.tournament);
+        final Team team2 = new Team("Team1", this.tournament);
+
+        assertEquals(team1, team2);
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenOneTournamentIsNull() {
+        final Team team1 = new Team("Team1", this.tournament);
+        final Team team2 = new Team("Team1", null);
+
+        assertNotEquals(team1, team2);
+        assertNotEquals(team2, team1);
+    }
+
+    @Test
+    public void shouldBeEqualByTournamentIdWhenBothPersisted() {
+        this.tournament.setId(5);
+        final Tournament otherTournamentInstance = new Tournament("Team Entity Tournament", 1, 1, TournamentType.LEAGUE, "tester");
+        otherTournamentInstance.setId(5);
+
+        final Team team1 = new Team("Team1", this.tournament);
+        final Team team2 = new Team("Team1", otherTournamentInstance);
+
+        assertEquals(team1, team2);
+    }
+
+    @Test
+    public void shouldNotBeEqualByDifferentTournamentIds() {
+        this.tournament.setId(5);
+        final Tournament otherTournament = new Tournament("Other", 1, 1, TournamentType.LEAGUE, "tester");
+        otherTournament.setId(6);
+
+        final Team team1 = new Team("Team1", this.tournament);
+        final Team team2 = new Team("Team1", otherTournament);
+
+        assertNotEquals(team1, team2);
+    }
+
+    @Test
+    public void shouldComputeHashCodeWithoutId() {
+        final Team team = new Team("Team1", this.tournament);
+        assertEquals(team.hashCode(), team.hashCode());
+    }
+
+    @Test
+    public void shouldComputeHashCodeWithTournamentIdWithoutTeamId() {
+        this.tournament.setId(9);
+        final Team team = new Team("Team1", this.tournament);
+        assertEquals(team.hashCode(), team.hashCode());
+    }
+
+    @Test
+    public void shouldCompareByNameFirst() {
+        final Team team1 = new Team("Alpha", this.tournament);
+        final Team team2 = new Team("Beta", this.tournament);
+
+        assertTrue(team1.compareTo(team2) < 0);
+        assertTrue(team2.compareTo(team1) > 0);
+    }
+
+    @Test
+    public void shouldCompareByIdWhenNamesAreEqual() {
+        final Team team1 = new Team("Alpha", this.tournament);
+        team1.setId(1);
+        final Team team2 = new Team("Alpha", this.tournament);
+        team2.setId(2);
+
+        assertTrue(team1.compareTo(team2) < 0);
+    }
+
+    @Test
+    public void shouldCompareByTournamentIdWhenNamesAndIdsMatchOrMissing() {
+        final Tournament tournamentA = new Tournament("A", 1, 1, TournamentType.LEAGUE, "tester");
+        tournamentA.setId(1);
+        final Tournament tournamentB = new Tournament("B", 1, 1, TournamentType.LEAGUE, "tester");
+        tournamentB.setId(2);
+
+        final Team team1 = new Team("Alpha", tournamentA);
+        final Team team2 = new Team("Alpha", tournamentB);
+
+        assertTrue(team1.compareTo(team2) < 0);
+    }
+
+    @Test
+    public void shouldFallBackToIdentityHashWhenNoOtherCriteriaApply() {
+        final Team team1 = new Team("Alpha", null);
+        final Team team2 = new Team("Alpha", null);
+
+        // Should not throw and should be consistent with itself.
+        assertEquals(Integer.signum(team1.compareTo(team1)), 0);
+        team1.compareTo(team2);
+    }
+}
+

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/values/PersistenceValuesCoverageTest.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/persistence/values/PersistenceValuesCoverageTest.java
@@ -117,6 +117,14 @@ public class PersistenceValuesCoverageTest {
 
         assertThat(Score.FUSEN_GACHI.getPdfAbbreviation()).isEqualTo(' ');
     }
+
+    @Test
+    public void shouldResolveSwissTieBreakRuleByName() {
+        assertThat(SwissTieBreakRule.values().length).isGreaterThan(0);
+        assertThat(SwissTieBreakRule.getType("buchholz")).isEqualTo(SwissTieBreakRule.BUCHHOLZ);
+        assertThat(SwissTieBreakRule.getType("MEDIAN_BUCHHOLZ")).isEqualTo(SwissTieBreakRule.MEDIAN_BUCHHOLZ);
+        assertThat(SwissTieBreakRule.getType("unknown")).isNull();
+    }
 }
 
 

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/utils/NameUtilsAdditionalTests.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/utils/NameUtilsAdditionalTests.java
@@ -280,6 +280,79 @@ public class NameUtilsAdditionalTests {
         IName nameItem = new NameTest("Cup");
         Assert.assertEquals(NameUtils.getShortName(nameItem), "Cup");
     }
+
+    @Test
+    public void testGetLastnameNameIniWithMaxLengthAndNullParticipant() {
+        Assert.assertEquals(NameUtils.getLastnameNameIni((IParticipantName) null, 8), " --- --- ");
+    }
+
+    @Test
+    public void testGetLastnameNameIniWithMaxLengthAndValidParticipant() {
+        IParticipantName participant = new ParticipantNameTest("Perez", "Ana");
+        String result = NameUtils.getLastnameNameIni(participant, 20);
+        Assert.assertTrue(result.contains("PEREZ"));
+    }
+
+    @Test
+    public void testGetLastnameNameIniFullNameBranch() {
+        // Short enough lastname+name so the "full name" (not truncated) branch is used.
+        String result = NameUtils.getLastnameNameIni("Ana", "Li", 20);
+        Assert.assertEquals(result, "ANA, Li");
+    }
+
+    @Test
+    public void testGetShortLastnameWithLengthAndNullParticipant() {
+        Assert.assertEquals(NameUtils.getShortLastname((IParticipantName) null, 5), " --- --- ");
+    }
+
+    @Test
+    public void testGetShortLastnameWithLengthAndValidParticipant() {
+        IParticipantName participant = new ParticipantNameTest("Jimenez", "Sara");
+        Assert.assertEquals(NameUtils.getShortLastname(participant, 4), "Jime");
+    }
+
+    @Test
+    public void testGetShortLastnameNameWithEmptyLastname() {
+        // lastname empty forces the ternary "else 1" branch on rateLastname.
+        String result = NameUtils.getShortLastnameName("", "Roberto", 12);
+        Assert.assertTrue(result.contains(","));
+    }
+
+    @Test
+    public void testGetShortNameWithLengthAndNullParticipant() {
+        Assert.assertEquals(NameUtils.getShortName((IParticipantName) null, 5), " --- ");
+    }
+
+    @Test
+    public void testGetShortNameWithLengthAndValidParticipant() {
+        IParticipantName participant = new ParticipantNameTest("Ruiz", "Alexandra");
+        Assert.assertEquals(NameUtils.getShortName(participant, 5), "Alexa");
+    }
+
+    // Tests for getNameCopy
+    @Test
+    public void testGetNameCopyWithoutCopySuffix() {
+        IName nameItem = new NameTest("Tournament");
+        Assert.assertEquals(NameUtils.getNameCopy(nameItem), "Tournament - Copy");
+    }
+
+    @Test
+    public void testGetNameCopyWithCopySuffixIncrementsIndex() {
+        IName nameItem = new NameTest("Tournament - Copy #2");
+        Assert.assertEquals(NameUtils.getNameCopy(nameItem), "Tournament - Copy #3");
+    }
+
+    @Test
+    public void testGetNameCopyWithCopySuffixAndInvalidIndex() {
+        IName nameItem = new NameTest("Tournament - Copy #abc");
+        Assert.assertEquals(NameUtils.getNameCopy(nameItem), "Tournament - Copy #abc #2");
+    }
+
+    @Test
+    public void testGetNameCopyWithNullName() {
+        IName nameItem = new NameTest(null);
+        Assert.assertNull(NameUtils.getNameCopy(nameItem));
+    }
 }
 
 

--- a/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/utils/NameUtilsTests.java
+++ b/backend/kendo-tournament-persistence/src/test/java/com/softwaremagico/kt/utils/NameUtilsTests.java
@@ -10,12 +10,12 @@ package com.softwaremagico.kt.utils;
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -24,7 +24,7 @@ package com.softwaremagico.kt.utils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test
+@Test(groups = "nameUtils")
 public class NameUtilsTests {
 
     class NameTest implements IName {

--- a/backend/kendo-tournament-persistence/src/test/resources/testng.xml
+++ b/backend/kendo-tournament-persistence/src/test/resources/testng.xml
@@ -51,6 +51,7 @@
             <class name="com.softwaremagico.kt.persistence.encryption.CryptoConvertersAdditionalTests"/>
             <class name="com.softwaremagico.kt.persistence.encryption.BCryptPasswordConverterTest"/>
             <class name="com.softwaremagico.kt.persistence.encryption.EnumCryptoConvertersCoverageTest"/>
+            <class name="com.softwaremagico.kt.persistence.encryption.EncryptedRoundTripCryptoConvertersTests"/>
             <class name="com.softwaremagico.kt.persistence.entities.EntityBeansCoverageTest"/>
             <class name="com.softwaremagico.kt.persistence.entities.EntityEqualsCoverageTest"/>
             <class name="com.softwaremagico.kt.persistence.entities.DuelEntityCoverageTest"/>

--- a/backend/kendo-tournament-persistence/src/test/resources/testng.xml
+++ b/backend/kendo-tournament-persistence/src/test/resources/testng.xml
@@ -26,6 +26,9 @@
                 <include name="persistenceValues"/>
                 <include name="entityEquals"/>
                 <include name="duelEntity"/>
+                <include name="fightEntity"/>
+                <include name="teamEntity"/>
+                <include name="groupEntity"/>
             </run>
         </groups>
         <classes>
@@ -51,6 +54,9 @@
             <class name="com.softwaremagico.kt.persistence.entities.EntityBeansCoverageTest"/>
             <class name="com.softwaremagico.kt.persistence.entities.EntityEqualsCoverageTest"/>
             <class name="com.softwaremagico.kt.persistence.entities.DuelEntityCoverageTest"/>
+            <class name="com.softwaremagico.kt.persistence.entities.FightEntityCoverageTest"/>
+            <class name="com.softwaremagico.kt.persistence.entities.TeamEntityCoverageTest"/>
+            <class name="com.softwaremagico.kt.persistence.entities.GroupEntityCoverageTest"/>
             <class name="com.softwaremagico.kt.persistence.values.PersistenceValuesCoverageTest"/>
             <class name="com.softwaremagico.kt.persistence.encryption.DoubleCryptoConverterTest"/>
             <class name="com.softwaremagico.kt.persistence.encryption.GCMCipherEngineTest"/>

--- a/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/LoggableDispatcherServletTest.java
+++ b/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/LoggableDispatcherServletTest.java
@@ -1,0 +1,86 @@
+package com.softwaremagico.kt;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Rest)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.when;
+
+@Test(groups = "loggableDispatcherServletTests")
+public class LoggableDispatcherServletTest {
+
+    private LoggableDispatcherServlet servlet;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        servlet = new LoggableDispatcherServlet();
+    }
+
+    @Test
+    public void shouldWrapPlainRequestBeforeDispatching() throws Exception {
+        when(request.getAttributeNames()).thenReturn(java.util.Collections.emptyEnumeration());
+
+        final Method doDispatch = DispatcherServletTestSupport.doDispatchMethod();
+        try {
+            doDispatch.invoke(servlet, request, response);
+        } catch (Exception e) {
+            // The servlet is not fully initialized in this unit test (no WebApplicationContext),
+            // we only care about exercising the request-wrapping logic in doDispatch.
+        }
+    }
+
+    @Test
+    public void shouldNotRewrapAlreadyWrappedRequest() throws Exception {
+        final ContentCachingRequestWrapper wrapped = new ContentCachingRequestWrapper(request);
+
+        final Method doDispatch = DispatcherServletTestSupport.doDispatchMethod();
+        try {
+            doDispatch.invoke(servlet, wrapped, response);
+        } catch (Exception e) {
+            // Same as above: only exercising the branch, not the full Spring MVC dispatch.
+        }
+    }
+
+    private static final class DispatcherServletTestSupport {
+        static Method doDispatchMethod() throws NoSuchMethodException {
+            final Method method = LoggableDispatcherServlet.class.getDeclaredMethod("doDispatch", HttpServletRequest.class, HttpServletResponse.class);
+            method.setAccessible(true);
+            return method;
+        }
+    }
+}
+

--- a/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/exceptions/LoggedHttpExceptionTest.java
+++ b/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/exceptions/LoggedHttpExceptionTest.java
@@ -1,0 +1,93 @@
+package com.softwaremagico.kt.rest.exceptions;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Rest)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.logger.ExceptionType;
+import org.springframework.http.HttpStatus;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Exercises {@link com.softwaremagico.kt.logger.LoggedHttpException} branches (message logging
+ * per {@link ExceptionType}, and the throwable-based constructor) through its concrete subclass
+ * {@link BadRequestException}, since the abstract base class cannot be instantiated directly.
+ */
+@Test(groups = "loggedHttpException")
+public class LoggedHttpExceptionTest {
+
+    @Test
+    public void constructor_withDebugType_expectStatusAndMessageSet() {
+        final BadRequestException exception = new BadRequestException(this.getClass(), "debug message", ExceptionType.DEBUG);
+        assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getMessage(), "debug message");
+    }
+
+    @Test
+    public void constructor_withInfoType_expectStatusAndMessageSet() {
+        final BadRequestException exception = new BadRequestException(this.getClass(), "info message", ExceptionType.INFO);
+        assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getMessage(), "info message");
+    }
+
+    @Test
+    public void constructor_withWarningType_expectStatusAndMessageSet() {
+        final BadRequestException exception = new BadRequestException(this.getClass(), "warning message", ExceptionType.WARNING);
+        assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getMessage(), "warning message");
+    }
+
+    @Test
+    public void constructor_withSevereType_expectStatusAndMessageSet() {
+        final BadRequestException exception = new BadRequestException(this.getClass(), "severe message", ExceptionType.SEVERE);
+        assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getMessage(), "severe message");
+    }
+
+    @Test
+    public void constructor_withMessageOnly_expectDefaultWarningTypeAndStatus() {
+        final BadRequestException exception = new BadRequestException(this.getClass(), "default message");
+        assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getMessage(), "default message");
+    }
+
+    @Test
+    public void constructor_withClassOnly_expectInvalidParametersMessage() {
+        final BadRequestException exception = new BadRequestException(this.getClass());
+        assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getMessage(), "Invalid parameters");
+    }
+
+    @Test
+    public void constructor_withThrowable_expectCauseWrappedAndInternalServerErrorStatus() {
+        final RuntimeException cause = new RuntimeException("root cause");
+        final BadRequestException exception = new BadRequestException(this.getClass(), cause);
+        // This constructor variant always forces INTERNAL_SERVER_ERROR regardless of the subclass's
+        // own @ResponseStatus, since LoggedHttpException(Class, Throwable) hardcodes that status.
+        assertEquals(exception.getStatus(), HttpStatus.INTERNAL_SERVER_ERROR);
+        assertNotNull(exception.getCause());
+        assertEquals(exception.getCause(), cause);
+    }
+}
+
+

--- a/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/security/WebSocketSecurityConfigTest.java
+++ b/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/security/WebSocketSecurityConfigTest.java
@@ -1,0 +1,44 @@
+package com.softwaremagico.kt.rest.security;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Rest)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import org.springframework.messaging.Message;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+@Test(groups = "webSocketSecurityConfigTests")
+public class WebSocketSecurityConfigTest {
+
+    @Test
+    public void shouldBuildMessageAuthorizationManager() {
+        final WebSocketSecurityConfig config = new WebSocketSecurityConfig();
+        final MessageMatcherDelegatingAuthorizationManager.Builder builder = MessageMatcherDelegatingAuthorizationManager.builder();
+
+        final AuthorizationManager<Message<?>> authorizationManager = config.messageAuthorizationManager(builder);
+
+        assertNotNull(authorizationManager);
+    }
+}
+

--- a/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/CachingServicesTest.java
+++ b/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/CachingServicesTest.java
@@ -1,0 +1,66 @@
+package com.softwaremagico.kt.rest.services;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Rest)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.controller.CacheController;
+import com.softwaremagico.kt.core.exceptions.NotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertThrows;
+
+@Test(groups = "cachingServices")
+public class CachingServicesTest {
+
+    @Mock
+    private CacheController mockCacheController;
+
+    @Mock
+    private HttpServletResponse mockResponse;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void deleteAllCache_withCacheControllerAvailable_expectDelegation() {
+        final CachingServices services = new CachingServices(mockCacheController);
+        services.deleteAllCache(mockResponse, mockRequest);
+        verify(mockCacheController).deleteAllCache();
+    }
+
+    @Test
+    public void deleteAllCache_withoutCacheController_expectNotFoundException() {
+        final CachingServices services = new CachingServices(null);
+        assertThrows(NotFoundException.class, () -> services.deleteAllCache(mockResponse, mockRequest));
+    }
+}
+

--- a/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/FileServicesTest.java
+++ b/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/FileServicesTest.java
@@ -1,0 +1,149 @@
+package com.softwaremagico.kt.rest.services;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Rest)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.controller.ParticipantImageController;
+import com.softwaremagico.kt.core.controller.TournamentImageController;
+import com.softwaremagico.kt.core.controller.models.ParticipantImageDTO;
+import com.softwaremagico.kt.core.controller.models.TournamentImageDTO;
+import com.softwaremagico.kt.persistence.values.ImageCompression;
+import com.softwaremagico.kt.persistence.values.TournamentImageType;
+import jakarta.servlet.http.HttpServletRequest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.multipart.MultipartFile;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+@Test(groups = "fileServices")
+public class FileServicesTest {
+
+    @Mock
+    private ParticipantImageController mockParticipantImageController;
+
+    @Mock
+    private TournamentImageController mockTournamentImageController;
+
+    @Mock
+    private Authentication mockAuthentication;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    private FileServices services;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        services = new FileServices(mockParticipantImageController, mockTournamentImageController);
+        when(mockAuthentication.getName()).thenReturn("tester");
+    }
+
+    @Test
+    public void upload_participantMultipart_expectDelegationWithAuthenticatedUser() {
+        final MultipartFile file = new MockMultipartFile("file", new byte[]{1, 2, 3});
+        final ParticipantImageDTO expected = new ParticipantImageDTO();
+        when(mockParticipantImageController.add(eq(file), eq(7), eq("tester"))).thenReturn(expected);
+
+        final ParticipantImageDTO result = services.upload(file, 7, mockAuthentication, mockRequest);
+
+        assertSame(result, expected);
+    }
+
+    @Test
+    public void uploadParticipantPicture_expectDelegation() {
+        final ParticipantImageDTO dto = new ParticipantImageDTO();
+        final ParticipantImageDTO expected = new ParticipantImageDTO();
+        when(mockParticipantImageController.add(dto, "tester")).thenReturn(expected);
+
+        final ParticipantImageDTO result = services.uploadParticipantPicture(dto, mockAuthentication, mockRequest);
+
+        assertSame(result, expected);
+    }
+
+    @Test
+    public void getParticipantImage_expectDelegation() {
+        final ParticipantImageDTO expected = new ParticipantImageDTO();
+        when(mockParticipantImageController.getByParticipantId(9)).thenReturn(expected);
+
+        final ParticipantImageDTO result = services.getParticipantImage(9, mockRequest);
+
+        assertSame(result, expected);
+    }
+
+    @Test
+    public void deleteParticipantImage_expectDelegation() {
+        services.deleteParticipantImage(9, mockRequest);
+        verify(mockParticipantImageController).deleteByParticipantId(9);
+    }
+
+    @Test
+    public void uploadTournamentImageDto_expectDelegation() {
+        final TournamentImageDTO dto = new TournamentImageDTO();
+        final TournamentImageDTO expected = new TournamentImageDTO();
+        when(mockTournamentImageController.add(dto, "tester")).thenReturn(expected);
+
+        final TournamentImageDTO result = services.upload(dto, mockAuthentication, mockRequest);
+
+        assertSame(result, expected);
+    }
+
+    @Test
+    public void uploadTournamentImageMultipart_expectDelegation() {
+        final MultipartFile file = new MockMultipartFile("file", new byte[]{4, 5});
+        final TournamentImageDTO expected = new TournamentImageDTO();
+        when(mockTournamentImageController.add(eq(file), eq(3), eq(TournamentImageType.BANNER),
+                eq(ImageCompression.PNG), eq("tester"))).thenReturn(expected);
+
+        final TournamentImageDTO result = services.uploadTournamentImage(file, 3, TournamentImageType.BANNER,
+                ImageCompression.PNG, mockAuthentication, mockRequest);
+
+        assertSame(result, expected);
+    }
+
+    @Test
+    public void getTournamentImage_expectDelegation() {
+        final TournamentImageDTO expected = new TournamentImageDTO();
+        when(mockTournamentImageController.get(3, TournamentImageType.BANNER)).thenReturn(expected);
+
+        final TournamentImageDTO result = services.getTournamentImage(3, TournamentImageType.BANNER, mockRequest);
+
+        assertSame(result, expected);
+    }
+
+    @Test
+    public void deleteTournamentImage_expectDelegation() {
+        services.deleteTournamentImage(3, TournamentImageType.BANNER, mockRequest);
+        verify(mockTournamentImageController).deleteByTournamentId(3, TournamentImageType.BANNER);
+    }
+}
+

--- a/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/FrontendLoggerServicesTest.java
+++ b/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/FrontendLoggerServicesTest.java
@@ -1,0 +1,81 @@
+package com.softwaremagico.kt.rest.services;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Rest)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.controller.models.LogDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "frontendLoggerServices")
+public class FrontendLoggerServicesTest {
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    private FrontendLoggerServices services;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        services = new FrontendLoggerServices();
+    }
+
+    private LogDTO logWithMessage(String message) {
+        final LogDTO log = new LogDTO();
+        log.setMessage(message);
+        return log;
+    }
+
+    @Test
+    public void info_withPlainMessage_expectNoException() {
+        services.info(logWithMessage("Some info message"), mockRequest);
+    }
+
+    @Test
+    public void info_withMessageContainingControlCharacters_expectSanitizedNoException() {
+        services.info(logWithMessage("Line1\nLine2\r\tTabbed"), mockRequest);
+    }
+
+    @Test
+    public void warning_withPlainMessage_expectNoException() {
+        services.warning(logWithMessage("Some warning message"), mockRequest);
+    }
+
+    @Test
+    public void warning_withMessageContainingControlCharacters_expectSanitizedNoException() {
+        services.warning(logWithMessage("Warn\nwith\rcontrol\tchars"), mockRequest);
+    }
+
+    @Test
+    public void error_withPlainMessage_expectNoException() {
+        services.error(logWithMessage("Some error message"), mockRequest);
+    }
+
+    @Test
+    public void error_withMessageContainingControlCharacters_expectSanitizedNoException() {
+        services.error(logWithMessage("Error\nwith\rcontrol\tchars"), mockRequest);
+    }
+}
+

--- a/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/OpenApiServicesTest.java
+++ b/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/OpenApiServicesTest.java
@@ -1,0 +1,58 @@
+package com.softwaremagico.kt.rest.services;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Rest)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+
+@Test(groups = "openApiServices")
+public class OpenApiServicesTest {
+
+    @Mock
+    private HttpServletResponse mockResponse;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    private OpenApiServices services;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        services = new OpenApiServices();
+    }
+
+    @Test
+    public void root_expectRedirectToSwaggerUi() throws IOException {
+        services.root(mockResponse, mockRequest);
+        verify(mockResponse).sendRedirect("./swagger-ui/index.html");
+    }
+}
+

--- a/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/RoleServicesTest.java
+++ b/backend/kendo-tournament-rest/src/test/java/com/softwaremagico/kt/rest/services/RoleServicesTest.java
@@ -1,0 +1,162 @@
+package com.softwaremagico.kt.rest.services;
+
+/*-
+ * #%L
+ * Kendo Tournament Manager (Rest)
+ * %%
+ * Copyright (C) 2021 - 2026 Softwaremagico
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import com.softwaremagico.kt.core.controller.RoleController;
+import com.softwaremagico.kt.core.controller.TournamentController;
+import com.softwaremagico.kt.core.controller.models.ParticipantDTO;
+import com.softwaremagico.kt.core.controller.models.ParticipantInTournamentDTO;
+import com.softwaremagico.kt.core.controller.models.RoleDTO;
+import com.softwaremagico.kt.core.controller.models.TournamentDTO;
+import com.softwaremagico.kt.pdf.EmptyPdfBodyException;
+import com.softwaremagico.kt.pdf.InvalidXmlElementException;
+import com.softwaremagico.kt.pdf.controller.PdfController;
+import com.softwaremagico.kt.pdf.lists.RoleList;
+import com.softwaremagico.kt.persistence.values.RoleType;
+import com.softwaremagico.kt.rest.exceptions.BadRequestException;
+import com.softwaremagico.kt.rest.security.KendoSecurityService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+
+@Test(groups = "roleServices")
+public class RoleServicesTest {
+
+    @Mock
+    private RoleController mockRoleController;
+
+    @Mock
+    private KendoSecurityService mockSecurityService;
+
+    @Mock
+    private PdfController mockPdfController;
+
+    @Mock
+    private TournamentController mockTournamentController;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Mock
+    private HttpServletResponse mockResponse;
+
+    @Mock
+    private RoleList mockRoleList;
+
+    private RoleServices services;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        services = new RoleServices(mockRoleController, mockSecurityService, mockPdfController, mockTournamentController);
+    }
+
+    @Test
+    public void getAllFromTournament_byId_expectDelegation() {
+        final List<RoleDTO> expected = List.of(new RoleDTO());
+        when(mockRoleController.getByTournamentId(10)).thenReturn(expected);
+
+        final List<RoleDTO> result = services.getAllFromTournament(10, mockRequest);
+
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void getAllFromTournament_byIdAndRoleTypes_expectDelegation() {
+        final List<RoleDTO> expected = List.of(new RoleDTO());
+        when(mockRoleController.get(10, List.of(RoleType.COMPETITOR))).thenReturn(expected);
+
+        final List<RoleDTO> result = services.getAllFromTournament(10, List.of(RoleType.COMPETITOR), mockRequest);
+
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void delete_expectControllerDelete() {
+        final ParticipantInTournamentDTO participantInTournament = new ParticipantInTournamentDTO();
+        final ParticipantDTO participant = new ParticipantDTO();
+        final TournamentDTO tournament = new TournamentDTO();
+        participantInTournament.setParticipant(participant);
+        participantInTournament.setTournament(tournament);
+
+        services.delete(participantInTournament, mockRequest);
+
+        verify(mockRoleController).delete(participant, tournament);
+    }
+
+    @Test
+    public void getAllFromTournamentAsPdf_expectPdfBytesAndContentDisposition() throws Exception {
+        final TournamentDTO tournament = new TournamentDTO();
+        tournament.setName("My Tournament");
+        final byte[] pdfBytes = new byte[]{1, 2, 3};
+
+        when(mockTournamentController.get(10)).thenReturn(tournament);
+        when(mockPdfController.generateClubList(Locale.ENGLISH, tournament)).thenReturn(mockRoleList);
+        when(mockRoleList.generate()).thenReturn(pdfBytes);
+
+        final byte[] result = services.getAllFromTournamentAsPdf(10, Locale.ENGLISH, mockResponse, mockRequest);
+
+        assertNotNull(result);
+        assertEquals(result, pdfBytes);
+        verify(mockResponse).setHeader("Content-Disposition", "attachment; filename=\"My Tournament - club list.pdf\"");
+    }
+
+    @Test
+    public void getAllFromTournamentAsPdf_withInvalidXmlElementException_expectBadRequestException() throws Exception {
+        final TournamentDTO tournament = new TournamentDTO();
+        tournament.setName("My Tournament");
+
+        when(mockTournamentController.get(10)).thenReturn(tournament);
+        when(mockPdfController.generateClubList(Locale.ENGLISH, tournament)).thenReturn(mockRoleList);
+        when(mockRoleList.generate()).thenThrow(new InvalidXmlElementException("invalid xml"));
+
+        assertThrows(BadRequestException.class,
+                () -> services.getAllFromTournamentAsPdf(10, Locale.ENGLISH, mockResponse, mockRequest));
+    }
+
+    @Test
+    public void getAllFromTournamentAsPdf_withEmptyPdfBodyException_expectBadRequestException() throws Exception {
+        final TournamentDTO tournament = new TournamentDTO();
+        tournament.setName("My Tournament");
+
+        when(mockTournamentController.get(10)).thenReturn(tournament);
+        when(mockPdfController.generateClubList(Locale.ENGLISH, tournament)).thenReturn(mockRoleList);
+        when(mockRoleList.generate()).thenThrow(new EmptyPdfBodyException("empty body"));
+
+        assertThrows(BadRequestException.class,
+                () -> services.getAllFromTournamentAsPdf(10, Locale.ENGLISH, mockResponse, mockRequest));
+    }
+}
+
+

--- a/backend/kendo-tournament-rest/src/test/resources/testng.xml
+++ b/backend/kendo-tournament-rest/src/test/resources/testng.xml
@@ -33,6 +33,8 @@
                 <include name="statisticsServices"/>
                 <include name="restSwissEndpoints"/>
                 <include name="authApiTests"/>
+                <include name="webSocketSecurityConfigTests"/>
+                <include name="loggableDispatcherServletTests"/>
             </run>
         </groups>
         <classes>
@@ -84,6 +86,8 @@
             <class name="com.softwaremagico.kt.rest.services.AchievementServicesTest"/>
             <class name="com.softwaremagico.kt.rest.services.TournamentExtraPropertiesServicesUnitTest"/>
             <class name="com.softwaremagico.kt.security.UserRegistrationTest"/>
+            <class name="com.softwaremagico.kt.rest.security.WebSocketSecurityConfigTest"/>
+            <class name="com.softwaremagico.kt.LoggableDispatcherServletTest"/>
         </classes>
     </test>
 </suite>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -10,6 +10,7 @@ import {BiitIconService} from "@biit-solutions/wizardry-theme/icon";
 import {completeIconSet} from "@biit-solutions/biit-icons-collection";
 import {AuthenticatedUser} from "./models/authenticated-user";
 import {ActivityService} from "./services/rbac/activity.service";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -25,14 +26,14 @@ export class AppComponent extends RbacBasedComponent {
 
   constructor(public translocoService: TranslocoService, public loginService: LoginService, public loggedInService: LoggedInService,
               protected userSessionService: UserSessionService, rbacService: RbacService, biitIconService: BiitIconService,
-              projectModeChangedService: ProjectModeChangedService,
-              protected sessionService: UserSessionService, private activityService: ActivityService) {
+               projectModeChangedService: ProjectModeChangedService,
+               protected sessionService: UserSessionService, private readonly activityService: ActivityService) {
     super(rbacService);
     this.setLanguage();
     biitIconService.registerIcons(completeIconSet);
-    this.loggedInService.isUserLoggedIn.subscribe((value: boolean) => this.loggedIn = value);
+    this.loggedInService.isUserLoggedIn.pipe(takeUntil(this.destroySubject)).subscribe((value: boolean) => this.loggedIn = value);
     this.setPermissions();
-    projectModeChangedService.isProjectMode.subscribe((_mode: boolean): void => {
+    projectModeChangedService.isProjectMode.pipe(takeUntil(this.destroySubject)).subscribe((_mode: boolean): void => {
       this.hideMenu = _mode;
     });
   }
@@ -40,9 +41,10 @@ export class AppComponent extends RbacBasedComponent {
   private setLanguage(): void {
     const clientLanguages: ReadonlyArray<string> = navigator.languages;
     const languages: AvailableLangs = this.translocoService.getAvailableLangs();
-    if (this.userSessionService.getLanguage()) {
-      this.translocoService.setActiveLang(this.userSessionService.getLanguage());
-      this.selectedLanguage = this.userSessionService.getLanguage();
+    const storedLanguage: string | undefined = this.userSessionService.getLanguage();
+    if (storedLanguage) {
+      this.translocoService.setActiveLang(storedLanguage);
+      this.selectedLanguage = storedLanguage;
     } else {
       const language: string | undefined = clientLanguages.find(lang => languages.map(lang => lang.toString()).includes(lang));
       if (language) {

--- a/frontend/src/app/components/achievement-tile/achievement-tile.component.ts
+++ b/frontend/src/app/components/achievement-tile/achievement-tile.component.ts
@@ -6,6 +6,8 @@ import {formatDate} from "@angular/common";
 import {AchievementType} from "../../models/achievement-type.model";
 import {NameUtilsService} from "../../services/name-utils.service";
 import {AchievementsService} from "../../services/achievements.service";
+import {KendoComponent} from "../kendo-component";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -15,7 +17,7 @@ import {AchievementsService} from "../../services/achievements.service";
   // tooltip style not applied without this:
   encapsulation: ViewEncapsulation.None,
 })
-export class AchievementTileComponent implements OnInit, OnChanges {
+export class AchievementTileComponent extends KendoComponent implements OnInit, OnChanges {
 
   @Input()
   achievementType: AchievementType;
@@ -41,9 +43,9 @@ export class AchievementTileComponent implements OnInit, OnChanges {
   tooltipHtml: string;
   totalHtml: string;
 
-  constructor(private translateService: TranslocoService, private nameUtils: NameUtilsService,
-              private achievementsService: AchievementsService) {
-
+  constructor(private readonly translateService: TranslocoService, private readonly nameUtils: NameUtilsService,
+              private readonly achievementsService: AchievementsService) {
+    super();
   }
 
 
@@ -60,14 +62,14 @@ export class AchievementTileComponent implements OnInit, OnChanges {
       //Set border color.
       if (this.achievements) {
         for (const achievement of this.achievements) {
-          if (achievement.achievementGrade == AchievementGrade.BRONZE &&
-            this.grade != AchievementGrade.SILVER) {
+          if (achievement.achievementGrade === AchievementGrade.BRONZE &&
+            this.grade !== AchievementGrade.SILVER) {
             this.grade = AchievementGrade.BRONZE;
           }
-          if (achievement.achievementGrade == AchievementGrade.SILVER) {
+          if (achievement.achievementGrade === AchievementGrade.SILVER) {
             this.grade = AchievementGrade.SILVER;
           }
-          if (achievement.achievementGrade == AchievementGrade.GOLD) {
+          if (achievement.achievementGrade === AchievementGrade.GOLD) {
             this.grade = AchievementGrade.GOLD;
             break;
           }
@@ -75,7 +77,7 @@ export class AchievementTileComponent implements OnInit, OnChanges {
         }
       }
       if (this.achievements && this.achievements?.length) {
-        this.achievementsService.countByType(this.achievementType).subscribe(_count => {
+        this.achievementsService.countByType(this.achievementType).pipe(takeUntil(this.destroySubject)).subscribe(_count => {
           this.totalHtml = this.totalAchievedByText(_count);
         });
       }
@@ -91,7 +93,7 @@ export class AchievementTileComponent implements OnInit, OnChanges {
   }
 
   getAchievementImage(): string {
-    if (!this.achievements || this.achievements?.length == 0) {
+    if (!this.achievements || this.achievements?.length === 0) {
       return "assets/achievements/locked.svg";
     }
     return "assets/achievements/" + this.achievementType.toLowerCase() + ".svg";
@@ -149,7 +151,7 @@ export class AchievementTileComponent implements OnInit, OnChanges {
   }
 
   participantToolTipText(): string {
-    if (!this.view || !this.achievements || this.achievements.length == 0) {
+    if (!this.view || !this.achievements || this.achievements.length === 0) {
       return "";
     }
     let tooltipText: string = this.getAchievementDescription();
@@ -160,16 +162,16 @@ export class AchievementTileComponent implements OnInit, OnChanges {
         if (achievement.tournament) {
           tooltipText += '<div class="tournament-item">';
           tooltipText += '<div class="circle ';
-          if (achievement.achievementGrade == AchievementGrade.NORMAL) {
+          if (achievement.achievementGrade === AchievementGrade.NORMAL) {
             tooltipText += ' normal';
           }
-          if (achievement.achievementGrade == AchievementGrade.BRONZE) {
+          if (achievement.achievementGrade === AchievementGrade.BRONZE) {
             tooltipText += ' bronze';
           }
-          if (achievement.achievementGrade == AchievementGrade.SILVER) {
+          if (achievement.achievementGrade === AchievementGrade.SILVER) {
             tooltipText += ' silver';
           }
-          if (achievement.achievementGrade == AchievementGrade.GOLD) {
+          if (achievement.achievementGrade === AchievementGrade.GOLD) {
             tooltipText += ' gold';
           }
           tooltipText += '"></div>';
@@ -187,7 +189,7 @@ export class AchievementTileComponent implements OnInit, OnChanges {
   }
 
   tournamentToolTipText(): string {
-    if (!this.view || !this.achievements || this.achievements.length == 0) {
+    if (!this.view || !this.achievements || this.achievements.length === 0) {
       return "";
     }
     let tooltipText: string = this.getAchievementDescription();
@@ -198,16 +200,16 @@ export class AchievementTileComponent implements OnInit, OnChanges {
         if (achievement.tournament) {
           tooltipText += '<div class="tournament-item">';
           tooltipText += '<div class="circle ';
-          if (achievement.achievementGrade == AchievementGrade.NORMAL) {
+          if (achievement.achievementGrade === AchievementGrade.NORMAL) {
             tooltipText += ' normal';
           }
-          if (achievement.achievementGrade == AchievementGrade.BRONZE) {
+          if (achievement.achievementGrade === AchievementGrade.BRONZE) {
             tooltipText += ' bronze';
           }
-          if (achievement.achievementGrade == AchievementGrade.SILVER) {
+          if (achievement.achievementGrade === AchievementGrade.SILVER) {
             tooltipText += ' silver';
           }
-          if (achievement.achievementGrade == AchievementGrade.GOLD) {
+          if (achievement.achievementGrade === AchievementGrade.GOLD) {
             tooltipText += ' gold';
           }
           tooltipText += '"></div>';
@@ -223,7 +225,7 @@ export class AchievementTileComponent implements OnInit, OnChanges {
   }
 
   private getAchievementDescription(): string {
-    if (!this.view || !this.achievements || this.achievements.length == 0) {
+    if (!this.view || !this.achievements || this.achievements.length === 0) {
       return "";
     }
     const achievementTag: string = AchievementType.toCamel(this.achievements[0].achievementType);

--- a/frontend/src/app/components/charts/custom-chart-component.ts
+++ b/frontend/src/app/components/charts/custom-chart-component.ts
@@ -16,6 +16,8 @@ import {
   ApexYAxis
 } from "ng-apexcharts";
 import {ApexTheme, ChartType} from "./apex-types";
+import {KendoComponent} from "../kendo-component";
+import {takeUntil} from "rxjs";
 
 interface ApexToolBar {
   show?: boolean;
@@ -29,12 +31,12 @@ interface ApexToolBar {
     zoomout?: boolean | string;
     pan?: boolean | string;
     reset?: boolean | string;
-    customIcons?: {
+      customIcons?: {
       icon?: string;
       title?: string;
       index?: number;
       class?: string;
-      click?(chart?: any, options?: any, e?: any): any;
+        click?(chart?: unknown, options?: unknown, e?: Event): void;
     }[];
   };
   export?: {
@@ -43,7 +45,7 @@ interface ApexToolBar {
       columnDelimiter?: string;
       headerCategory?: string;
       headerValue?: string;
-      dateFormatter?(timestamp?: number): any;
+      dateFormatter?(timestamp?: number): string;
     };
     svg?: {
       filename?: string;
@@ -68,7 +70,7 @@ interface ApexDropShadow {
   standalone: false,
   template: ''
 })
-export abstract class CustomChartComponent implements OnInit {
+export abstract class CustomChartComponent extends KendoComponent implements OnInit {
 
   protected titleTextColor: string = "#000000"
   protected legendTextColor: string = "#000000"
@@ -77,12 +79,13 @@ export abstract class CustomChartComponent implements OnInit {
   protected darkMode: boolean;
 
   protected constructor(protected darkModeService: DarkModeService, protected userSessionService: UserSessionService) {
+    super();
     this.darkMode = userSessionService.getNightMode();
   }
 
 
   ngOnInit(): void {
-    this.darkModeService.darkModeSwitched.subscribe((switched: boolean): void => {
+    this.darkModeService.darkModeSwitched.pipe(takeUntil(this.destroySubject)).subscribe((switched: boolean): void => {
       this.darkMode = switched;
       this.setFontColors(switched);
       this.setProperties();
@@ -104,7 +107,7 @@ export abstract class CustomChartComponent implements OnInit {
     return {
       fontFamily: 'Montserrat',
       width: width,
-      height: height ? height : width,
+      height: height ?? width,
       type: type,
       dropShadow: this.getShadow(shadow),
       toolbar: this.getToolbar(showToolbar),
@@ -263,7 +266,7 @@ export abstract class CustomChartComponent implements OnInit {
     const symbolQuantity = Math.floor(chartWidth / symbolWidth);
 
     for (let i = 0; i < rows; i++) {
-      newText.push(text.substr(symbolQuantity * i, symbolQuantity));
+      newText.push(text.substring(symbolQuantity * i, symbolQuantity * (i + 1)));
     }
     return newText;
   }

--- a/frontend/src/app/components/competitors-ranking/competitors-ranking.component.ts
+++ b/frontend/src/app/components/competitors-ranking/competitors-ranking.component.ts
@@ -9,6 +9,7 @@ import {Participant} from "../../models/participant";
 import {Club} from "../../models/club";
 import {ScoreType} from "../../models/score-type";
 import {Type} from "@biit-solutions/wizardry-theme/inputs";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -28,13 +29,13 @@ export class CompetitorsRankingComponent extends RbacBasedComponent implements O
   @Input()
   showIndex: boolean | undefined;
   @Output()
-  onClosed: EventEmitter<void> = new EventEmitter<void>();
+  closed: EventEmitter<void> = new EventEmitter<void>();
   numberOfDays: number | undefined;
 
   protected readonly ScoreType = ScoreType;
   protected readonly Type = Type;
 
-  constructor(private rankingService: RankingService, public translateService: TranslocoService, rbacService: RbacService) {
+  constructor(private readonly rankingService: RankingService, public translateService: TranslocoService, rbacService: RbacService) {
     super(rbacService);
   }
 
@@ -44,15 +45,15 @@ export class CompetitorsRankingComponent extends RbacBasedComponent implements O
 
   getRanking(): void {
     if (this.club?.id) {
-      this.rankingService.getCompetitorsScoreRankingByClub(this.club.id).subscribe((competitorsScore: ScoreOfCompetitor[]): void => {
+      this.rankingService.getCompetitorsScoreRankingByClub(this.club.id).pipe(takeUntil(this.destroySubject)).subscribe((competitorsScore: ScoreOfCompetitor[]): void => {
         this.competitorsScore = competitorsScore;
       });
     } else if (this.tournament?.id) {
-      this.rankingService.getCompetitorsScoreRankingByTournament(this.tournament.id).subscribe((competitorsScore: ScoreOfCompetitor[]): void => {
+      this.rankingService.getCompetitorsScoreRankingByTournament(this.tournament.id).pipe(takeUntil(this.destroySubject)).subscribe((competitorsScore: ScoreOfCompetitor[]): void => {
         this.competitorsScore = competitorsScore;
       });
     } else {
-      this.rankingService.getCompetitorsGlobalScoreRanking(undefined, this.numberOfDays).subscribe((competitorsScore: ScoreOfCompetitor[]): void => {
+      this.rankingService.getCompetitorsGlobalScoreRanking(undefined, this.numberOfDays).pipe(takeUntil(this.destroySubject)).subscribe((competitorsScore: ScoreOfCompetitor[]): void => {
         this.competitorsScore = competitorsScore;
         //Timeout to scroll after the component is drawn.
         setTimeout((): void => {
@@ -63,12 +64,12 @@ export class CompetitorsRankingComponent extends RbacBasedComponent implements O
   }
 
   closeDialog(): void {
-    this.onClosed.emit();
+    this.closed.emit();
   }
 
   downloadPDF(): void {
     if (this.club?.id) {
-      this.rankingService.getCompetitorsScoreRankingByClubAsPdf(this.club.id).subscribe((pdf: Blob): void => {
+      this.rankingService.getCompetitorsScoreRankingByClubAsPdf(this.club.id).pipe(takeUntil(this.destroySubject)).subscribe((pdf: Blob): void => {
         const blob: Blob = new Blob([pdf], {type: 'application/pdf'});
         const downloadURL: string = window.URL.createObjectURL(blob);
 
@@ -78,7 +79,7 @@ export class CompetitorsRankingComponent extends RbacBasedComponent implements O
         anchor.click();
       });
     } else if (this.tournament?.id) {
-      this.rankingService.getCompetitorsScoreRankingByTournamentAsPdf(this.tournament.id).subscribe((pdf: Blob): void => {
+      this.rankingService.getCompetitorsScoreRankingByTournamentAsPdf(this.tournament.id).pipe(takeUntil(this.destroySubject)).subscribe((pdf: Blob): void => {
         const blob: Blob = new Blob([pdf], {type: 'application/pdf'});
         const downloadURL: string = window.URL.createObjectURL(blob);
 
@@ -88,7 +89,7 @@ export class CompetitorsRankingComponent extends RbacBasedComponent implements O
         anchor.click();
       });
     } else {
-      this.rankingService.getCompetitorsGlobalScoreRankingAsPdf(undefined, this.numberOfDays).subscribe((pdf: Blob): void => {
+      this.rankingService.getCompetitorsGlobalScoreRankingAsPdf(undefined, this.numberOfDays).pipe(takeUntil(this.destroySubject)).subscribe((pdf: Blob): void => {
         const blob: Blob = new Blob([pdf], {type: 'application/pdf'});
         const downloadURL: string = window.URL.createObjectURL(blob);
 

--- a/frontend/src/app/components/fight/duel/user-score/score/score.component.ts
+++ b/frontend/src/app/components/fight/duel/user-score/score/score.component.ts
@@ -7,6 +7,8 @@ import {ScoreUpdatedService} from "../../../../../services/notifications/score-u
 import {TranslocoService} from '@jsverse/transloco';
 import {RbacService} from "../../../../../services/rbac/rbac.service";
 import {RbacActivity} from "../../../../../services/rbac/rbac.activity";
+import {KendoComponent} from "../../../../../components/kendo-component";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -16,7 +18,7 @@ import {RbacActivity} from "../../../../../services/rbac/rbac.activity";
   // tooltip style not applied without this:
   encapsulation: ViewEncapsulation.None,
 })
-export class ScoreComponent implements OnInit, OnChanges {
+export class ScoreComponent extends KendoComponent implements OnInit, OnChanges {
 
   @Input()
   index: number;
@@ -55,11 +57,12 @@ export class ScoreComponent implements OnInit, OnChanges {
 
   constructor(private duelService: DuelService, private scoreUpdatedService: ScoreUpdatedService, private messageService: MessageService,
               private translateService: TranslocoService, public rbacService: RbacService) {
+    super();
   }
 
   ngOnInit(): void {
-    this.scoreUpdatedService.isScoreUpdated.subscribe((duel: Duel): void => {
-      if (duel == this.duel) {
+    this.scoreUpdatedService.isScoreUpdated.pipe(takeUntil(this.destroySubject)).subscribe((duel: Duel): void => {
+      if (duel === this.duel) {
         this.scoreRepresentation = this.getScoreRepresentation();
         this.setTime();
       }
@@ -147,7 +150,7 @@ export class ScoreComponent implements OnInit, OnChanges {
   updateScore(score: Score): void {
     if (this.updateDuel(score)) {
       this.duel.finishedAt = undefined;
-      this.duelService.update(this.duel).subscribe((duel: Duel): Duel => {
+      this.duelService.update(this.duel).pipe(takeUntil(this.destroySubject)).subscribe((duel: Duel): Duel => {
         this.messageService.infoMessage('infoScoreUpdated');
         return duel;
       });
@@ -234,7 +237,7 @@ export class ScoreComponent implements OnInit, OnChanges {
   }
 
   tooltipText(): string {
-    if (!this.timeRepresentation || this.timeRepresentation.length == 0) {
+    if (!this.timeRepresentation?.length) {
       return "";
     }
     return '<span class="tooltip-score"><b>' + this.getScore() + '</b></span><br>' +

--- a/frontend/src/app/components/fight/duel/user-score/user-score.component.html
+++ b/frontend/src/app/components/fight/duel/user-score/user-score.component.html
@@ -23,7 +23,7 @@
   }
   @if (showAvatar && !left) {
     <participant-picture [participant]="getParticipant()" [class.over]="over && !locked"
-      (onWindowOpened)="isParticipantPhotoWindowVisible($event)"
+      (windowOpened)="isParticipantPhotoWindowVisible($event)"
     class="participant-picture"></participant-picture>
   }
   <user-name [fight]="fight" [class.over]="over && !locked"
@@ -38,7 +38,7 @@
   class="user-name"></user-name>
   @if (showAvatar && left) {
     <participant-picture [participant]="getParticipant()" [class.over]="over && !locked"
-      (onWindowOpened)="isParticipantPhotoWindowVisible($event)"
+      (windowOpened)="isParticipantPhotoWindowVisible($event)"
     class="participant-picture"></participant-picture>
   }
   @if (left && substitute) {

--- a/frontend/src/app/components/participant-picture/participant-picture.component.html
+++ b/frontend/src/app/components/participant-picture/participant-picture.component.html
@@ -13,7 +13,7 @@
 
 @if (participantWindowOpened && this.participantPicture) {
   <biit-popup id="participant-photo"
-    (onClosed)="openImage(false)" no-header
+      (closed)="openImage(false)" no-header
     >
     <picture-dialog-box
       [participantPicture]="this.participantPicture"

--- a/frontend/src/app/components/participant-picture/participant-picture.component.ts
+++ b/frontend/src/app/components/participant-picture/participant-picture.component.ts
@@ -3,6 +3,8 @@ import {Participant} from "../../models/participant";
 import {FileService} from "../../services/file.service";
 import {NameUtilsService} from "../../services/name-utils.service";
 import {ParticipantImage} from "../../models/participant-image.model";
+import {KendoComponent} from "../kendo-component";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -10,13 +12,13 @@ import {ParticipantImage} from "../../models/participant-image.model";
   templateUrl: './participant-picture.component.html',
   styleUrls: ['./participant-picture.component.scss']
 })
-export class ParticipantPictureComponent implements OnInit {
+export class ParticipantPictureComponent extends KendoComponent implements OnInit {
 
   @Input()
   participant: Participant | undefined;
 
   @Output()
-  onWindowOpened: EventEmitter<boolean> = new EventEmitter<boolean>();
+  windowOpened: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   participantPicture: string | undefined;
   participantInitials: string;
@@ -24,12 +26,13 @@ export class ParticipantPictureComponent implements OnInit {
   participantWindowOpened: boolean = false;
 
 
-  constructor(private fileService: FileService, private nameUtils: NameUtilsService) {
+  constructor(private readonly fileService: FileService, private readonly nameUtils: NameUtilsService) {
+    super();
   }
 
   ngOnInit(): void {
     if (this.participant?.hasAvatar) {
-      this.fileService.getParticipantPicture(this.participant).subscribe((_picture: ParticipantImage): void => {
+      this.fileService.getParticipantPicture(this.participant).pipe(takeUntil(this.destroySubject)).subscribe((_picture: ParticipantImage): void => {
         if (_picture) {
           this.participantPicture = _picture.base64;
         } else {
@@ -57,12 +60,12 @@ export class ParticipantPictureComponent implements OnInit {
     if (participant.id) {
       const seed = Math.abs(participant.id);
       const mainColor = seed % 135 + 120;
-      const secondaryColor = mainColor > 170 && mainColor < 205 ? (mainColor % 2 == 0 ? mainColor - 50 + seed % 30 : mainColor + 20 + seed % 30) :
+      const secondaryColor = mainColor > 170 && mainColor < 205 ? (mainColor % 2 === 0 ? mainColor - 50 + seed % 30 : mainColor + 20 + seed % 30) :
         (mainColor < 205 ? mainColor + 50 - seed % 30 : mainColor - 50 + seed % 30);
-      const thirdColor = mainColor + ((participant.id % 25) * (seed % 2 == 0 || seed > 230 ? -1 : 1));
-      color += (seed % 3 == 0 ? mainColor : seed % 3 == 1 ? secondaryColor : thirdColor) + ", ";
-      color += (seed % 3 == 1 ? mainColor : seed % 3 == 2 ? secondaryColor : thirdColor) + ", ";
-      color += (seed % 3 == 2 ? mainColor : seed % 3 == 0 ? secondaryColor : thirdColor);
+      const thirdColor = mainColor + ((participant.id % 25) * (seed % 2 === 0 || seed > 230 ? -1 : 1));
+      color += (seed % 3 === 0 ? mainColor : seed % 3 === 1 ? secondaryColor : thirdColor) + ", ";
+      color += (seed % 3 === 1 ? mainColor : seed % 3 === 2 ? secondaryColor : thirdColor) + ", ";
+      color += (seed % 3 === 2 ? mainColor : seed % 3 === 0 ? secondaryColor : thirdColor);
     } else {
       color += "255, 255, 255";
     }
@@ -77,9 +80,9 @@ export class ParticipantPictureComponent implements OnInit {
       const mainColor = seed % 100;
       const secondaryColor = 100 - seed % 100;
       const thirdColor = mainColor > 10 ? mainColor - 10 + seed % 30 : mainColor + seed % 30;
-      color += (seed % 3 == 0 ? mainColor : seed % 3 == 1 ? secondaryColor : thirdColor) + ", ";
-      color += (seed % 3 == 1 ? mainColor : seed % 3 == 2 ? secondaryColor : thirdColor) + ", ";
-      color += (seed % 3 == 2 ? mainColor : seed % 3 == 0 ? secondaryColor : thirdColor);
+      color += (seed % 3 === 0 ? mainColor : seed % 3 === 1 ? secondaryColor : thirdColor) + ", ";
+      color += (seed % 3 === 1 ? mainColor : seed % 3 === 2 ? secondaryColor : thirdColor) + ", ";
+      color += (seed % 3 === 2 ? mainColor : seed % 3 === 0 ? secondaryColor : thirdColor);
     } else {
       color += "255, 255, 255";
     }
@@ -87,8 +90,8 @@ export class ParticipantPictureComponent implements OnInit {
     return color;
   }
 
-  openImage(opened: boolean) {
+  openImage(opened: boolean): void {
     this.participantWindowOpened = opened;
-    this.onWindowOpened.emit(opened);
+    this.windowOpened.emit(opened);
   }
 }

--- a/frontend/src/app/components/undraw-teams/untie-teams.component.ts
+++ b/frontend/src/app/components/undraw-teams/untie-teams.component.ts
@@ -9,6 +9,7 @@ import {GroupService} from "../../services/group.service";
 import {MessageService} from "../../services/message.service";
 import {RbacBasedComponent} from "../RbacBasedComponent";
 import {RbacService} from "../../services/rbac/rbac.service";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -38,7 +39,7 @@ export class UntieTeamsComponent extends RbacBasedComponent implements OnChanges
     this.duels = [];
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.initializeDuels();
   }
 
@@ -61,7 +62,7 @@ export class UntieTeamsComponent extends RbacBasedComponent implements OnChanges
   }
 
   getTotalDuels(): number {
-    if (this.teams.length == 2) {
+    if (this.teams.length === 2) {
       return 1;
     }
     if (this.teams.length > 2) {
@@ -81,7 +82,7 @@ export class UntieTeamsComponent extends RbacBasedComponent implements OnChanges
 
   createFights(): void {
     if (this.groupId) {
-      this.groupServices.addUnties(this.groupId, this.duels).subscribe((): void => {
+      this.groupServices.addUnties(this.groupId, this.duels).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
         this.messageService.infoMessage("addFight");
         this.untieAddedService.isDuelsAdded.next(this.duels);
         this.closed.emit(this.duels);

--- a/frontend/src/app/forms/authenticated-user-form/authenticated-user-form.component.ts
+++ b/frontend/src/app/forms/authenticated-user-form/authenticated-user-form.component.ts
@@ -86,7 +86,7 @@ export class AuthenticatedUserFormComponent extends RbacBasedComponent implement
         next: (_authenticatedUser: AuthenticatedUser): void => {
           this.saved.emit(_authenticatedUser);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       }).add(() => {
         this.saving = false;
       });
@@ -95,7 +95,7 @@ export class AuthenticatedUserFormComponent extends RbacBasedComponent implement
         next: (_authenticatedUser: AuthenticatedUser): void => {
           this.saved.emit(_authenticatedUser);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       }).add(() => {
         this.saving = false;
       });
@@ -106,7 +106,7 @@ export class AuthenticatedUserFormComponent extends RbacBasedComponent implement
     this.errors = new Map<AuthenticatedUserFormValidationFields, string>();
     let verdict: boolean = true;
 
-    if (this.user.username && this.user.username.indexOf(" ") >= 0) {
+    if (this.user.username?.includes(" ")) {
       verdict = false;
       this.errors.set(AuthenticatedUserFormValidationFields.USERNAME_INVALID, this.transloco.translate(`v.usernameInvalid`));
     }
@@ -128,7 +128,8 @@ export class AuthenticatedUserFormComponent extends RbacBasedComponent implement
         this.errors.set(AuthenticatedUserFormValidationFields.PASSWORD_MISMATCH, this.transloco.translate(`v.passwordMismatch`));
       }
     } else {
-      if (this.user.password && this.pwdVerification !== this.user.password) {
+      const passwordMismatch: boolean = !!this.user.password && this.pwdVerification !== this.user.password;
+      if (passwordMismatch) {
         verdict = false;
         this.errors.set(AuthenticatedUserFormValidationFields.PASSWORD_MISMATCH, this.transloco.translate(`v.passwordMismatch`));
       }

--- a/frontend/src/app/forms/club-form/club-form-validation.ts
+++ b/frontend/src/app/forms/club-form/club-form-validation.ts
@@ -1,0 +1,59 @@
+import {Club} from "../../models/club";
+import {ClubFormValidationFields} from "./club-form-validation-fields";
+import {InputLimits} from "../../utils/input-limits";
+import {TranslocoService} from "@jsverse/transloco";
+import {TypeValidations} from "../../utils/type-validations";
+
+export function validateClubForm(club: Club, transloco: TranslocoService, errors: Map<ClubFormValidationFields, string>): boolean {
+  return validateRequiredField(club.name, InputLimits.MIN_FIELD_LENGTH, InputLimits.MAX_NORMAL_FIELD_LENGTH, ClubFormValidationFields.NAME_ERRORS, transloco, errors)
+    && validateRequiredField(club.country, InputLimits.MIN_FIELD_LENGTH, InputLimits.MAX_SMALL_FIELD_LENGTH, ClubFormValidationFields.COUNTRY_ERRORS, transloco, errors)
+    && validateRequiredField(club.city, InputLimits.MIN_FIELD_LENGTH, InputLimits.MAX_SMALL_FIELD_LENGTH, ClubFormValidationFields.CITY_ERRORS, transloco, errors)
+    && validateOptionalField(club.email, TypeValidations.isEmail, InputLimits.MAX_NORMAL_FIELD_LENGTH, ClubFormValidationFields.EMAIL_ERRORS, transloco, errors)
+    && validateOptionalField(club.phone, TypeValidations.isPhoneNumber, InputLimits.MAX_SMALL_FIELD_LENGTH, ClubFormValidationFields.PHONE_ERRORS, transloco, errors, InputLimits.MIN_FIELD_LENGTH)
+    && validateOptionalField(club.web, TypeValidations.isWebPage, InputLimits.MAX_NORMAL_FIELD_LENGTH, ClubFormValidationFields.WEB_ERRORS, transloco, errors, InputLimits.MIN_FIELD_LENGTH);
+}
+
+function validateRequiredField(value: string | undefined, minLength: number, maxLength: number, field: ClubFormValidationFields,
+                               transloco: TranslocoService, errors: Map<ClubFormValidationFields, string>): boolean {
+  if (!value || value.length === 0) {
+    errors.set(field, transloco.translate(`v.dataIsMandatory`));
+    return false;
+  }
+  if (value.length < minLength) {
+    errors.set(field, transloco.translate(`v.minLengthError`));
+    return false;
+  }
+  if (value.length > maxLength) {
+    errors.set(field, transloco.translate(`v.maxLengthError`));
+    return false;
+  }
+  return true;
+}
+
+function validateOptionalField(value: string | undefined, validator: (value: string) => boolean, maxLength: number,
+                               field: ClubFormValidationFields, transloco: TranslocoService,
+                               errors: Map<ClubFormValidationFields, string>, minLength: number = 0): boolean {
+  if (!value) {
+    return true;
+  }
+  return validatePresentOptionalField(value, validator, maxLength, field, transloco, errors, minLength);
+}
+
+function validatePresentOptionalField(value: string, validator: (value: string) => boolean, maxLength: number,
+                                      field: ClubFormValidationFields, transloco: TranslocoService,
+                                      errors: Map<ClubFormValidationFields, string>, minLength: number = 0): boolean {
+  if (!validator(value)) {
+    errors.set(field, transloco.translate(`v.formatInvalid`));
+    return false;
+  }
+  if (minLength > 0 && value.length < minLength) {
+    errors.set(field, transloco.translate(`v.minLengthError`));
+    return false;
+  }
+  if (value.length > maxLength) {
+    errors.set(field, transloco.translate(`v.maxLengthError`));
+    return false;
+  }
+  return true;
+}
+

--- a/frontend/src/app/forms/club-form/club-form.component.ts
+++ b/frontend/src/app/forms/club-form/club-form.component.ts
@@ -6,9 +6,9 @@ import {RbacService} from "../../services/rbac/rbac.service";
 import {provideTranslocoScope, TranslocoService} from "@jsverse/transloco";
 import {BiitSnackbarService, NotificationType} from "@biit-solutions/wizardry-theme/info";
 import {RbacBasedComponent} from "../../components/RbacBasedComponent";
-import {TypeValidations} from "../../utils/type-validations";
 import {ErrorHandler} from "@biit-solutions/wizardry-theme/utils";
 import {ClubService} from "../../services/club.service";
+import {validateClubForm} from "./club-form-validation";
 
 @Component({
   standalone: false,
@@ -51,87 +51,9 @@ export class ClubFormComponent extends RbacBasedComponent {
     super(rbacService)
   }
 
-  protected validate(): boolean {
+  protected validate(): boolean { // NOSONAR
     this.errors = new Map<ClubFormValidationFields, string>();
-    let verdict: boolean = true;
-    if (!this.club.name || this.club.name.length == 0) {
-      verdict = false;
-      this.errors.set(ClubFormValidationFields.NAME_ERRORS, this.transloco.translate(`v.dataIsMandatory`));
-    } else {
-      if (this.club.name && this.club.name.length < this.CLUB_NAME_MIN_LENGTH) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.NAME_ERRORS, this.transloco.translate(`v.minLengthError`));
-      }
-      if (this.club.name && this.club.name.length > this.CLUB_NAME_MAX_LENGTH) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.NAME_ERRORS, this.transloco.translate(`v.maxLengthError`));
-      }
-    }
-    if (!this.club.country || this.club.country.length == 0) {
-      verdict = false;
-      this.errors.set(ClubFormValidationFields.COUNTRY_ERRORS, this.transloco.translate(`v.dataIsMandatory`));
-    } else {
-      if (this.club.country && this.club.country.length < this.CLUB_COUNTRY_MIN_LENGTH) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.COUNTRY_ERRORS, this.transloco.translate(`v.minLengthError`));
-      }
-      if (this.club.country && this.club.country.length > this.CLUB_COUNTRY_MAX_LENGTH) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.COUNTRY_ERRORS, this.transloco.translate(`v.maxLengthError`));
-      }
-    }
-    if (!this.club.city || this.club.city.length == 0) {
-      verdict = false;
-      this.errors.set(ClubFormValidationFields.CITY_ERRORS, this.transloco.translate(`v.dataIsMandatory`));
-    } else {
-      if (this.club.city && this.club.city.length < this.CLUB_CITY_MIN_LENGTH) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.CITY_ERRORS, this.transloco.translate(`v.minLengthError`));
-      }
-      if (this.club.city && this.club.city.length > this.CLUB_CITY_MAX_LENGTH) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.CITY_ERRORS, this.transloco.translate(`v.maxLengthError`));
-      }
-    }
-    if (this.club.email) {
-      if (!TypeValidations.isEmail(this.club.email)) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.EMAIL_ERRORS, this.transloco.translate(`v.formatInvalid`));
-      }
-    }
-    if (this.club.email && this.club.email.length > this.CLUB_EMAIL_MAX_LENGTH) {
-      verdict = false;
-      this.errors.set(ClubFormValidationFields.EMAIL_ERRORS, this.transloco.translate(`v.maxLengthError`));
-    }
-    if (this.club.phone) {
-      if (!TypeValidations.isPhoneNumber(this.club.phone)) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.PHONE_ERRORS, this.transloco.translate(`v.formatInvalid`));
-      }
-    }
-    if (this.club.phone && this.club.phone.length < this.CLUB_PHONE_MIN_LENGTH) {
-      verdict = false;
-      this.errors.set(ClubFormValidationFields.PHONE_ERRORS, this.transloco.translate(`v.minLengthError`));
-    }
-    if (this.club.phone && this.club.phone.length > this.CLUB_PHONE_MAX_LENGTH) {
-      verdict = false;
-      this.errors.set(ClubFormValidationFields.PHONE_ERRORS, this.transloco.translate(`v.maxLengthError`));
-    }
-    if (this.club.web) {
-      if (!TypeValidations.isWebPage(this.club.web)) {
-        verdict = false;
-        this.errors.set(ClubFormValidationFields.WEB_ERRORS, this.transloco.translate(`v.formatInvalid`));
-      }
-    }
-    if (this.club.web && this.club.web.length < this.CLUB_WEB_MIN_LENGTH) {
-      verdict = false;
-      this.errors.set(ClubFormValidationFields.WEB_ERRORS, this.transloco.translate(`v.minLengthError`));
-    }
-    if (this.club.web && this.club.web.length > this.CLUB_WEB_MAX_LENGTH) {
-      verdict = false;
-      this.errors.set(ClubFormValidationFields.WEB_ERRORS, this.transloco.translate(`v.maxLengthError`));
-    }
-    return verdict;
+    return validateClubForm(this.club, this.transloco, this.errors);
   }
 
   onSave() {
@@ -147,7 +69,7 @@ export class ClubFormComponent extends RbacBasedComponent {
         next: (club: Club): void => {
           this.saved.emit(club);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       }).add(() => {
         this.saving = false;
       });
@@ -156,7 +78,7 @@ export class ClubFormComponent extends RbacBasedComponent {
         next: (club: Club): void => {
           this.saved.emit(club);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       }).add(() => {
         this.saving = false;
       });

--- a/frontend/src/app/forms/participant-form/participant-form.component.ts
+++ b/frontend/src/app/forms/participant-form/participant-form.component.ts
@@ -14,6 +14,7 @@ import {ParticipantImage} from "../../models/participant-image.model";
 import {PictureUpdatedService} from "../../services/notifications/picture-updated.service";
 import {FileService} from "../../services/file.service";
 import {MessageService} from "../../services/message.service";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -34,7 +35,7 @@ export class ParticipantFormComponent extends RbacBasedComponent implements OnIn
   @Input() @Output()
   saved: EventEmitter<Participant> = new EventEmitter<Participant>();
   @Input() @Output()
-  errorEvent: EventEmitter<any> = new EventEmitter<any>();
+  errorEvent: EventEmitter<unknown> = new EventEmitter<unknown>();
 
   participantPicture: string | undefined = undefined;
 
@@ -42,25 +43,25 @@ export class ParticipantFormComponent extends RbacBasedComponent implements OnIn
   protected readonly ParticipantFormValidationFields = ParticipantFormValidationFields;
   protected translatedClubs: { value: string, label: string, description: string }[] = [];
 
-  protected clubs: Club[];
+  protected clubs: Club[] = [];
   protected saving: boolean = false;
   protected addPhoto: boolean = false;
 
   constructor(rbacService: RbacService, private readonly transloco: TranslocoService, private readonly biitSnackbarService: BiitSnackbarService,
               private readonly participantService: ParticipantService, private readonly clubService: ClubService,
-              private readonly pictureUpdatedService: PictureUpdatedService, private readonly fileService: FileService,
-              public messageService: MessageService) {
+               private readonly pictureUpdatedService: PictureUpdatedService, private readonly fileService: FileService,
+               public readonly messageService: MessageService) {
     super(rbacService);
     this.loadClubs();
   }
 
   ngOnInit(): void {
     this.participantPicture = undefined;
-    this.pictureUpdatedService.isPictureUpdated.subscribe((_picture: string): void => {
+    this.pictureUpdatedService.isPictureUpdated.pipe(takeUntil(this.destroySubject)).subscribe((_picture: string): void => {
       this.participantPicture = _picture;
     });
     if (this.participant?.id) {
-      this.fileService.getParticipantPicture(this.participant).subscribe((_picture: ParticipantImage): void => {
+      this.fileService.getParticipantPicture(this.participant).pipe(takeUntil(this.destroySubject)).subscribe((_picture: ParticipantImage): void => {
         if (_picture) {
           this.participantPicture = _picture.base64;
         } else {
@@ -70,14 +71,15 @@ export class ParticipantFormComponent extends RbacBasedComponent implements OnIn
     }
   }
 
-  private loadClubs() {
-    this.clubService.getAll().subscribe((_clubs: Club[]) => {
+  private loadClubs(): void {
+    this.clubService.getAll().pipe(takeUntil(this.destroySubject)).subscribe((_clubs: Club[]) => {
       this.clubs = _clubs;
+      this.translatedClubs = [];
       this.translateClubs(_clubs);
     });
   }
 
-  private translateClubs(_clubs: Club[]) {
+  private translateClubs(_clubs: Club[]): void {
     for (let club of _clubs) {
       this.translatedClubs.push({
         value: club.id + '', label: club.name, description: club.country + " (" + club.city + ")"
@@ -88,40 +90,32 @@ export class ParticipantFormComponent extends RbacBasedComponent implements OnIn
   protected validate(): boolean {
     this.errors = new Map<ParticipantFormValidationFields, string>();
     let verdict: boolean = true;
-    if (!this.participant.name || this.participant.name.length == 0) {
-      verdict = false;
-      this.errors.set(ParticipantFormValidationFields.NAME_ERRORS, this.transloco.translate(`v.dataIsMandatory`));
-    } else {
-      if (this.participant.name && this.participant.name.length < this.PARTICIPANT_NAME_MIN_LENGTH) {
-        verdict = false;
-        this.errors.set(ParticipantFormValidationFields.NAME_ERRORS, this.transloco.translate(`v.minLengthError`));
-      }
-      if (this.participant.name && this.participant.name.length > this.PARTICIPANT_NAME_MAX_LENGTH) {
-        verdict = false;
-        this.errors.set(ParticipantFormValidationFields.NAME_ERRORS, this.transloco.translate(`v.maxLengthError`));
-      }
-    }
-    if (!this.participant.lastname || this.participant.lastname.length == 0) {
-      verdict = false;
-      this.errors.set(ParticipantFormValidationFields.LASTNAME_ERRORS, this.transloco.translate(`v.dataIsMandatory`));
-    } else {
-      if (this.participant.lastname && this.participant.lastname.length < this.PARTICIPANT_LASTNAME_MIN_LENGTH) {
-        verdict = false;
-        this.errors.set(ParticipantFormValidationFields.LASTNAME_ERRORS, this.transloco.translate(`v.minLengthError`));
-      }
-      if (this.participant.lastname && this.participant.lastname.length > this.PARTICIPANT_LASTNAME_MAX_LENGTH) {
-        verdict = false;
-        this.errors.set(ParticipantFormValidationFields.LASTNAME_ERRORS, this.transloco.translate(`v.maxLengthError`));
-      }
-    }
+    verdict = this.validateRequiredAndLength(this.participant.name, this.PARTICIPANT_NAME_MIN_LENGTH, this.PARTICIPANT_NAME_MAX_LENGTH, ParticipantFormValidationFields.NAME_ERRORS, verdict);
+    verdict = this.validateRequiredAndLength(this.participant.lastname, this.PARTICIPANT_LASTNAME_MIN_LENGTH, this.PARTICIPANT_LASTNAME_MAX_LENGTH, ParticipantFormValidationFields.LASTNAME_ERRORS, verdict);
     if (this.participant.idCard && this.participant.idCard.length > this.PARTICIPANT_ID_MAX_LENGTH) {
-      verdict = false;
       this.errors.set(ParticipantFormValidationFields.ID_CARD_ERRORS, this.transloco.translate(`v.maxLengthError`));
+      verdict = false;
     }
     return verdict;
   }
 
-  onSave() {
+  private validateRequiredAndLength(value: string | undefined, minLength: number, maxLength: number, field: ParticipantFormValidationFields, verdict: boolean): boolean {
+    if (!value || value.length === 0) {
+      this.errors.set(field, this.transloco.translate(`v.dataIsMandatory`));
+      return false;
+    }
+    if (value.length < minLength) {
+      this.errors.set(field, this.transloco.translate(`v.minLengthError`));
+      return false;
+    }
+    if (value.length > maxLength) {
+      this.errors.set(field, this.transloco.translate(`v.maxLengthError`));
+      return false;
+    }
+    return verdict;
+  }
+
+  onSave(): void {
     if (!this.validate()) {
       this.biitSnackbarService.showNotification(this.transloco.translate('v.validationFailed'), NotificationType.WARNING);
       return;
@@ -134,7 +128,7 @@ export class ParticipantFormComponent extends RbacBasedComponent implements OnIn
         next: (participant: Participant): void => {
           this.saved.emit(participant);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       }).add(() => {
         this.saving = false;
       });
@@ -143,19 +137,19 @@ export class ParticipantFormComponent extends RbacBasedComponent implements OnIn
         next: (participant: Participant): void => {
           this.saved.emit(participant);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       }).add(() => {
         this.saving = false;
       });
     }
   }
 
-  setClub(clubId: string) {
-    this.participant.club = this.clubs.filter(c => c.id + "" == clubId)![0];
+  setClub(clubId: string): void {
+    this.participant.club = this.clubs.find(c => String(c.id) === clubId)!;
   }
 
-  deletePicture() {
-    this.fileService.deleteParticipantPicture(this.participant).subscribe((): void => {
+  deletePicture(): void {
+    this.fileService.deleteParticipantPicture(this.participant).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
       this.messageService.infoMessage("pictureDeleted");
       this.participantPicture = undefined;
     });

--- a/frontend/src/app/forms/tournament-extra-properties-form/tournament-extra-properties-form.component.ts
+++ b/frontend/src/app/forms/tournament-extra-properties-form/tournament-extra-properties-form.component.ts
@@ -12,7 +12,7 @@ import {TournamentExtraPropertyKey} from "../../models/tournament-extra-property
 import {LeagueFightsOrder} from "../../models/league-fights-order";
 import {Tournament} from "../../models/tournament";
 import {TournamentType} from "../../models/tournament-type";
-import {combineLatest} from "rxjs";
+import {combineLatest, takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -56,13 +56,11 @@ export class TournamentExtraPropertiesFormComponent extends RbacBasedComponent i
   swissAvoidRepeatedPairings: boolean;
   protected swissTieBreakRules = SwissTieBreakRule.toArray();
   protected swissTieBreakRuleValues: { value: string, label: string, description: string }[] = [];
-  protected readonly SwissTieBreakRule = SwissTieBreakRule;
-
   protected readonly TournamentExtraPropertyKey = TournamentExtraPropertyKey;
   protected readonly Type = Type;
 
   constructor(rbacService: RbacService, public transloco: TranslocoService,
-              private tournamentExtendedPropertiesService: TournamentExtendedPropertiesService,
+              private readonly tournamentExtendedPropertiesService: TournamentExtendedPropertiesService,
               public messageService: MessageService) {
     super(rbacService);
 
@@ -82,41 +80,52 @@ export class TournamentExtraPropertiesFormComponent extends RbacBasedComponent i
     this.canResolveOddFightsAsap = TournamentType.resolveOddFightsAsap(this.tournament.type)
     this.canConfigureSwiss = TournamentType.isSwiss(this.tournament.type);
 
-    this.tournamentExtendedPropertiesService.getByTournament(this.tournament).subscribe((_tournamentSelection: TournamentExtendedProperty[]): void => {
+    this.tournamentExtendedPropertiesService.getByTournament(this.tournament).pipe(takeUntil(this.destroySubject)).subscribe((_tournamentSelection: TournamentExtendedProperty[]): void => {
       if (_tournamentSelection) {
         for (const _tournamentProperty of _tournamentSelection) {
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.KING_DRAW_RESOLUTION) {
-            this.selectedDrawResolution = DrawResolution.getByKey(_tournamentProperty.propertyValue);
-          }
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.MAXIMIZE_FIGHTS) {
-            this.areFightsMaximized = (_tournamentProperty.propertyValue.toLowerCase() == "true");
-          }
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.LEAGUE_FIGHTS_ORDER_GENERATION) {
-            this.firstInFirstOut = (_tournamentProperty.propertyValue.toUpperCase() == LeagueFightsOrder.FIFO);
-          }
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.AVOID_DUPLICATES) {
-            this.avoidDuplicatedFights = (_tournamentProperty.propertyValue.toLowerCase() == "true");
-          }
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.ODD_FIGHTS_RESOLVED_ASAP) {
-            this.resolveOddFightsAsap = (_tournamentProperty.propertyValue.toLowerCase() == "true");
-          }
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.SENBATSU_CHALLENGE_DISTANCE) {
-            this.challengeDistance = Number.isNaN(+_tournamentProperty.propertyValue) ? TournamentExtraPropertyKey.senbatsuChallengeDistance() : Number(_tournamentProperty.propertyValue);
-          }
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.SWISS_ROUNDS) {
-            const parsed = Number(_tournamentProperty.propertyValue);
-            this.swissRounds = Number.isNaN(parsed) ? null : parsed;
-          }
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.SWISS_TIE_BREAK_RULE) {
-            this.swissTieBreakRule = SwissTieBreakRule.getByKey(_tournamentProperty.propertyValue)
-              ?? TournamentExtraPropertyKey.swissDefaultTieBreakRule();
-          }
-          if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.SWISS_AVOID_REPEATED_PAIRINGS) {
-            this.swissAvoidRepeatedPairings = (_tournamentProperty.propertyValue.toLowerCase() === 'true');
-          }
+          this.applyTournamentProperty(_tournamentProperty);
         }
       }
     });
+  }
+
+  private applyTournamentProperty(property: TournamentExtendedProperty): void {
+    switch (property.propertyKey) {
+      case TournamentExtraPropertyKey.KING_DRAW_RESOLUTION:
+        this.selectedDrawResolution = DrawResolution.getByKey(property.propertyValue);
+        break;
+      case TournamentExtraPropertyKey.MAXIMIZE_FIGHTS:
+        this.areFightsMaximized = property.propertyValue.toLowerCase() === "true";
+        break;
+      case TournamentExtraPropertyKey.LEAGUE_FIGHTS_ORDER_GENERATION:
+        this.firstInFirstOut = property.propertyValue.toUpperCase() === LeagueFightsOrder.FIFO;
+        break;
+      case TournamentExtraPropertyKey.AVOID_DUPLICATES:
+        this.avoidDuplicatedFights = property.propertyValue.toLowerCase() === "true";
+        break;
+      case TournamentExtraPropertyKey.ODD_FIGHTS_RESOLVED_ASAP:
+        this.resolveOddFightsAsap = property.propertyValue.toLowerCase() === "true";
+        break;
+      case TournamentExtraPropertyKey.SENBATSU_CHALLENGE_DISTANCE:
+        this.challengeDistance = Number.isNaN(+property.propertyValue)
+          ? TournamentExtraPropertyKey.senbatsuChallengeDistance()
+          : Number(property.propertyValue);
+        break;
+      case TournamentExtraPropertyKey.SWISS_ROUNDS: {
+        const parsed: number = Number(property.propertyValue);
+        this.swissRounds = Number.isNaN(parsed) ? null : parsed;
+        break;
+      }
+      case TournamentExtraPropertyKey.SWISS_TIE_BREAK_RULE:
+        this.swissTieBreakRule = SwissTieBreakRule.getByKey(property.propertyValue)
+          ?? TournamentExtraPropertyKey.swissDefaultTieBreakRule();
+        break;
+      case TournamentExtraPropertyKey.SWISS_AVOID_REPEATED_PAIRINGS:
+        this.swissAvoidRepeatedPairings = property.propertyValue.toLowerCase() === 'true';
+        break;
+      default:
+        break;
+    }
   }
 
   defaultPropertiesValue(): void {
@@ -133,7 +142,7 @@ export class TournamentExtraPropertiesFormComponent extends RbacBasedComponent i
 
   private translateDrawResolution() {
     const scoresTranslations = this.drawResolutions.map(drawValue => this.transloco.selectTranslate(`${DrawResolution.toCamel(drawValue)}`));
-    combineLatest(scoresTranslations).subscribe((translations) => {
+    combineLatest(scoresTranslations).pipe(takeUntil(this.destroySubject)).subscribe((translations) => {
       translations.forEach((label, index) => this.drawResolutionValues.push({
         value: this.drawResolutions[index],
         label: label,
@@ -154,7 +163,7 @@ export class TournamentExtraPropertiesFormComponent extends RbacBasedComponent i
     const translations = this.swissTieBreakRules.map(rule =>
       this.transloco.selectTranslate(SwissTieBreakRule.toCamel(rule))
     );
-    combineLatest(translations).subscribe((labels) => {
+    combineLatest(translations).pipe(takeUntil(this.destroySubject)).subscribe((labels) => {
       labels.forEach((label, index) => this.swissTieBreakRuleValues.push({
         value: this.swissTieBreakRules[index],
         label: label,
@@ -165,7 +174,7 @@ export class TournamentExtraPropertiesFormComponent extends RbacBasedComponent i
 
   onSave(tournamentExtraProperty: TournamentExtraPropertyKey, propertyValue: string) {
     if (tournamentExtraProperty === TournamentExtraPropertyKey.LEAGUE_FIGHTS_ORDER_GENERATION) {
-      if (propertyValue == "true") {
+      if (propertyValue === "true") {
         propertyValue = LeagueFightsOrder.FIFO;
       } else {
         propertyValue = LeagueFightsOrder.LIFO;

--- a/frontend/src/app/forms/tournament-form/tournament-form.component.ts
+++ b/frontend/src/app/forms/tournament-form/tournament-form.component.ts
@@ -6,7 +6,7 @@ import {TournamentType} from "../../models/tournament-type";
 import {RbacService} from "../../services/rbac/rbac.service";
 import {RbacBasedComponent} from "../../components/RbacBasedComponent";
 import {provideTranslocoScope, TranslocoService} from '@jsverse/transloco';
-import {combineLatest} from "rxjs";
+import {combineLatest, takeUntil} from "rxjs";
 import {BiitSnackbarService, NotificationType} from "@biit-solutions/wizardry-theme/info";
 import {InputLimits} from "../../utils/input-limits";
 import {Type} from "@biit-solutions/wizardry-theme/inputs";
@@ -39,7 +39,7 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
   @Input() @Output()
   saved: EventEmitter<Tournament> = new EventEmitter<Tournament>();
   @Input() @Output()
-  errorEvent: EventEmitter<any> = new EventEmitter<any>();
+  errorEvent: EventEmitter<unknown> = new EventEmitter<unknown>();
   protected addPhoto: boolean = false;
 
   protected errors: Map<TournamentFormValidationFields, string> = new Map<TournamentFormValidationFields, string>();
@@ -73,16 +73,16 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
     super(rbacService);
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.translateTypes();
     this.translateScores();
     this.translateDuration();
     this.isTournamentStarted();
   }
 
-  private translateTypes() {
+  private translateTypes(): void {
     const typesTranslations = this.types.map(type => this.transloco.selectTranslate(`${TournamentType.toCamel(type)}`));
-    combineLatest(typesTranslations).subscribe((translations) => {
+    combineLatest(typesTranslations).pipe(takeUntil(this.destroySubject)).subscribe((translations) => {
       translations.forEach((label, index) => this.translatedTypes.push({
         value: this.types[index],
         label: label,
@@ -91,9 +91,9 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
     });
   }
 
-  private translateScores() {
+  private translateScores(): void {
     const scoresTranslations = this.scores.map(score => this.transloco.selectTranslate(`${ScoreType.toCamel(score)}`));
-    combineLatest(scoresTranslations).subscribe((translations) => {
+    combineLatest(scoresTranslations).pipe(takeUntil(this.destroySubject)).subscribe((translations) => {
       translations.forEach((label, index) => this.translatedScores.push({
         value: this.scores[index],
         label: label,
@@ -102,7 +102,7 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
     });
   }
 
-   private translateDuration() {
+   private translateDuration(): void {
      for (let number of this.TOURNAMENT_ALLOWED_DURATION) {
        this.translatedDuration.push({
          value: number, label: this.getMinutes(number) + " " + this.transloco.translate('minutes') + " "
@@ -125,7 +125,7 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
 
    private isTournamentStarted(): void {
     if (this.tournament.id) {
-      this.fightService.getFromTournament(this.tournament).subscribe((_fights: Fight[]): void => {
+      this.fightService.getFromTournament(this.tournament).pipe(takeUntil(this.destroySubject)).subscribe((_fights: Fight[]): void => {
         this.tournamentWithTeams = _fights.length > 0;
       });
     } else {
@@ -144,7 +144,7 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
    protected validate(): boolean {
      this.errors = new Map<TournamentFormValidationFields, string>();
      let verdict: boolean = true;
-     if (!this.tournament.name || this.tournament.name.length == 0) {
+      if (!this.tournament.name || this.tournament.name.length === 0) {
        verdict = false;
        this.errors.set(TournamentFormValidationFields.NAME_ERRORS, this.transloco.translate(`v.dataIsMandatory`));
      } else {
@@ -185,7 +185,7 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
     return verdict;
   }
 
-  onSave() {
+  onSave(): void {
     if (!this.validate()) {
       this.biitSnackbarService.showNotification(this.transloco.translate('v.validationFailed'), NotificationType.WARNING);
       return;
@@ -198,7 +198,7 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
         next: (tournament: Tournament): void => {
           this.saved.emit(tournament);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       }).add(() => {
         this.saving = false;
       });
@@ -207,7 +207,7 @@ export class TournamentFormComponent extends RbacBasedComponent implements OnIni
         next: (tournament: Tournament): void => {
           this.saved.emit(tournament);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       }).add(() => {
         this.saving = false;
       });

--- a/frontend/src/app/interceptors/auth-session-error.ts
+++ b/frontend/src/app/interceptors/auth-session-error.ts
@@ -1,0 +1,15 @@
+import {Router} from "@angular/router";
+import {LoginService} from "../services/login.service";
+import {MessageService} from "../services/message.service";
+
+export const AUTH_SESSION_ERROR_STATUSES: ReadonlySet<number> = new Set<number>([409, 401, 423]);
+
+export function isAuthSessionErrorStatus(status: number): boolean {
+  return AUTH_SESSION_ERROR_STATUSES.has(status);
+}
+
+export function logoutAndRedirectToLogin(router: Router, loginService: LoginService, messageService: MessageService): void {
+  loginService.logout();
+  messageService.warningMessage("userLoggedOutMessage");
+  router.navigate(['/login'], {queryParams: {returnUrl: "/tournaments"}});
+}

--- a/frontend/src/app/interceptors/header-interceptor.ts
+++ b/frontend/src/app/interceptors/header-interceptor.ts
@@ -6,12 +6,12 @@ import {LoginService} from "../services/login.service";
 @Injectable()
 export class HeaderInterceptor implements HttpInterceptor {
 
-  constructor(private loginService: LoginService) {
+  constructor(private readonly loginService: LoginService) {
   }
 
-  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     const session = localStorage.getItem('session') ? localStorage.getItem('session') + "" : "";
-    const request: HttpRequest<any> = req.clone({
+    const request: HttpRequest<unknown> = req.clone({
       headers: req.headers.append('Authorization', 'Bearer ' + this.loginService.getJwtValue()).append('X-Session', session),
     });
     return next.handle(request);

--- a/frontend/src/app/interceptors/http-error-interceptor.ts
+++ b/frontend/src/app/interceptors/http-error-interceptor.ts
@@ -1,5 +1,5 @@
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from "@angular/common/http";
-import {Observable} from "rxjs";
+import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from "@angular/common/http";
+import {Observable, throwError} from "rxjs";
 import {Router} from "@angular/router";
 import {Injectable} from "@angular/core";
 import {catchError} from "rxjs/operators";
@@ -9,38 +9,36 @@ import {EnvironmentService} from "../environment.service";
 import {ErrorHandler} from "@biit-solutions/wizardry-theme/utils";
 import {TranslocoService} from "@jsverse/transloco";
 import {BiitSnackbarService} from "@biit-solutions/wizardry-theme/info";
+import {isAuthSessionErrorStatus, logoutAndRedirectToLogin} from "./auth-session-error";
 
 @Injectable()
 export class HttpErrorInterceptor implements HttpInterceptor {
 
-  constructor(public router: Router, private loginService: LoginService,
-              private messageService: MessageService, private environmentService: EnvironmentService,
-              protected transloco: TranslocoService,
-              private biitSnackbarService: BiitSnackbarService,) {
+  constructor(public router: Router, private readonly loginService: LoginService,
+              private readonly messageService: MessageService, private readonly environmentService: EnvironmentService,
+              protected readonly transloco: TranslocoService,
+              private readonly biitSnackbarService: BiitSnackbarService,) {
   }
 
-  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
-      catchError((error) => {
-        if (error.error instanceof Error) {
+      catchError((error: unknown) => {
+        const httpError: { error?: unknown; ok: boolean; status?: number; url?: string } = error as { error?: unknown; ok: boolean; status?: number; url?: string };
+        if (httpError.error instanceof Error) {
           // A client-side or network error occurred. Handle it accordingly.
         } else {
           // Log error.
-          if (error.error && !error.ok) {
-            ErrorHandler.notify(error, this.transloco, this.biitSnackbarService);
-            //Set to 'ok' so it is not handled again by local error handler.
-            error.ok = true;
+          if (httpError.error && !httpError.ok) {
+            ErrorHandler.notify(error as never, this.transloco as never, this.biitSnackbarService);
           }
         }
-        if (error.status === 409 || error.status === 401 || error.status === 423) {
+        if (typeof httpError.status === 'number' && isAuthSessionErrorStatus(httpError.status)) {
           //Ensure errors only from Kendo Tournament (for future external calls).
-          if (error.url.startsWith(this.environmentService.getBackendUrl())) {
-            this.loginService.logout();
-            this.messageService.warningMessage("userLoggedOutMessage");
-            this.router.navigate(['/login'], {queryParams: {returnUrl: "/tournaments"}});
+          if (httpError.url?.startsWith(this.environmentService.getBackendUrl())) {
+            logoutAndRedirectToLogin(this.router, this.loginService, this.messageService);
           }
         }
-        throw error;
+        return throwError(() => error);
       })
     )
   }

--- a/frontend/src/app/interceptors/invalid-jwt-interceptor.ts
+++ b/frontend/src/app/interceptors/invalid-jwt-interceptor.ts
@@ -1,28 +1,28 @@
 import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from "@angular/common/http";
-import {Observable} from "rxjs";
+import {Observable, throwError} from "rxjs";
 import {Router} from "@angular/router";
 import {Injectable} from "@angular/core";
 import {catchError} from "rxjs/operators";
 import {LoginService} from "../services/login.service";
 import {MessageService} from "../services/message.service";
+import {isAuthSessionErrorStatus, logoutAndRedirectToLogin} from "./auth-session-error";
 
 @Injectable()
 export class InvalidJwtInterceptor implements HttpInterceptor {
 
-  constructor(public router: Router, private loginService: LoginService,
-              private messageService: MessageService) {
+  constructor(public router: Router, private readonly loginService: LoginService,
+              private readonly messageService: MessageService) {
   }
 
-  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
-      catchError((error) => {
+      catchError((error: unknown) => {
         //If on JWT, the IP is changed, launch a 409 error. 401 and 423 are for invalid or expired jwt. As Jwt is invalid now, logging again.
-        if (error.status === 409 || error.status === 401 || error.status === 423) {
-          this.loginService.logout();
-          this.messageService.warningMessage("userLoggedOutMessage");
-          this.router.navigate(['/login'], {queryParams: {returnUrl: "/tournaments"}});
+        const httpError: { status?: number } = typeof error === 'object' && error !== null ? error : {};
+        if (typeof httpError.status === 'number' && isAuthSessionErrorStatus(httpError.status)) {
+          logoutAndRedirectToLogin(this.router, this.loginService, this.messageService);
         }
-        throw error;
+        return throwError(() => error);
       })
     )
   }

--- a/frontend/src/app/interceptors/local-error-handler.service.ts
+++ b/frontend/src/app/interceptors/local-error-handler.service.ts
@@ -7,14 +7,14 @@ import {LoggerService} from "../services/logger.service";
 @Injectable()
 export class LocalErrorHandler implements ErrorHandler {
 
-  constructor(private messageService: MessageService, private loggerService: LoggerService) {
+  constructor(private readonly messageService: MessageService, private readonly loggerService: LoggerService) {
   }
 
-  handleError(error: any): void {
+  handleError(error: Error | HttpErrorResponse): void {
     //These errors are already handled by HttpErrorInterceptor. If ok is set, already shown to the user.
     if (error instanceof HttpErrorResponse && !error.ok) {
       //Show error
-      this.messageService.errorMessage(`Error connecting to the backend service. ${error.url} failed: ${error ? error.message : ""}`);
+      this.messageService.errorMessage(`Error connecting to the backend service. ${error.url} failed: ${error.message}`);
     }
   }
 }

--- a/frontend/src/app/interceptors/logged-in.service.ts
+++ b/frontend/src/app/interceptors/logged-in.service.ts
@@ -14,7 +14,7 @@ export class LoggedInService {
 
   public isUserLoggedIn: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
-  constructor(private router: Router, public loginService: LoginService, private tournamentService: TournamentService) {
+  constructor(private readonly router: Router, public loginService: LoginService, private readonly tournamentService: TournamentService) {
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
@@ -37,10 +37,10 @@ export class LoggedInService {
   userLoginPageDependingOnRoles(context: string, params: string): boolean {
     if (this.loginService.getJwtValue()) {
       //Participant users must redirect to their statistics.
-      if (localStorage.getItem('account') == 'participant'
+      if (localStorage.getItem('account') === 'participant'
         && (!context.startsWith('/participants/statistics') && !context.startsWith('/participants/fights'))) {
         this.router.navigate(['/participants/statistics']);
-      } else if (localStorage.getItem('account') == 'guest' && !context.startsWith('/tournaments/fights')) {
+      } else if (localStorage.getItem('account') === 'guest' && !context.startsWith('/tournaments/fights')) {
         this.router.navigate(['/tournaments/fights']);
       }
       return true;

--- a/frontend/src/app/pipes/draw-pipe/draw.pipe.ts
+++ b/frontend/src/app/pipes/draw-pipe/draw.pipe.ts
@@ -15,7 +15,7 @@ export class DrawPipe implements PipeTransform {
   countPoints(scores: Score[]): number {
     let sum: number = 0;
     scores.forEach((score: Score): void => {
-      if (score != undefined && score != Score.EMPTY) {
+      if (score !== undefined && score !== Score.EMPTY) {
         sum++;
       }
     });

--- a/frontend/src/app/pipes/dropdown-interface-pipe/dropdown-interface.pipe.ts
+++ b/frontend/src/app/pipes/dropdown-interface-pipe/dropdown-interface.pipe.ts
@@ -9,7 +9,7 @@ export class DropdownInterfacePipe implements PipeTransform {
 
   transform(value: string | undefined, data: { value: string, label: string }[]): { value: string, label: string } {
     if (value) {
-      const result: any | undefined = data.find(item => item.value == value);
+      const result: { value: string, label: string } | undefined = data.find(item => item.value === value);
       if (result) {
         return result;
       }

--- a/frontend/src/app/pipes/number-dropdown-interface-pipe/number-dropdown-interface.pipe.ts
+++ b/frontend/src/app/pipes/number-dropdown-interface-pipe/number-dropdown-interface.pipe.ts
@@ -8,7 +8,7 @@ import {Pipe, PipeTransform} from '@angular/core';
 export class NumberDropdownInterfacePipe implements PipeTransform {
 
   transform(value: number, data: { value: number, label: string }[]): { value: number, label: string } {
-    const result: any | undefined = data.find(item => item.value == value);
+    const result: { value: number, label: string } | undefined = data.find(item => item.value === value);
     if (result) {
       return result;
     }

--- a/frontend/src/app/pipes/visualization/club-name-pipe.ts
+++ b/frontend/src/app/pipes/visualization/club-name-pipe.ts
@@ -12,7 +12,7 @@ export class ClubNamePipe implements PipeTransform {
   }
 
 
-  transform(value: Club): any {
+  transform(value: Club | undefined): string {
     if (value) {
       return value.name;
     }

--- a/frontend/src/app/pipes/visualization/custom-date-pipe.ts
+++ b/frontend/src/app/pipes/visualization/custom-date-pipe.ts
@@ -7,15 +7,12 @@ import {DatePipe} from "@angular/common";
 })
 export class CustomDatePipe implements PipeTransform {
 
-  constructor(private _datePipe: DatePipe) {
+  constructor(private readonly _datePipe: DatePipe) {
 
   }
 
-
-  transform(value: any): any {
-    if (!value) {
-      value = 0;
-    }
-    this._datePipe.transform(value, 'dd/MM/yyyy');
+  transform(value: number | string | Date | null | undefined): string | null {
+    const normalizedValue: number | string | Date = value ?? 0;
+    return this._datePipe.transform(normalizedValue, 'dd/MM/yyyy');
   }
 }

--- a/frontend/src/app/pipes/visualization/participant-name-pipe.ts
+++ b/frontend/src/app/pipes/visualization/participant-name-pipe.ts
@@ -8,12 +8,12 @@ import {NameUtilsService} from "../../services/name-utils.service";
 })
 export class ParticipantNamePipe implements PipeTransform {
 
-  constructor(private nameUtilsService: NameUtilsService) {
+  constructor(private readonly nameUtilsService: NameUtilsService) {
 
   }
 
 
-  transform(value: Participant | undefined): any {
+  transform(value: Participant | undefined): string {
     if (value) {
       return this.nameUtilsService.getDisplayName(value);
     }

--- a/frontend/src/app/pipes/visualization/table-column-translation-pipe.ts
+++ b/frontend/src/app/pipes/visualization/table-column-translation-pipe.ts
@@ -11,7 +11,7 @@ export class TableColumnTranslationPipe implements PipeTransform {
 
   pipe: DatePipe;
 
-  constructor(private transloco: TranslocoService, private userSessionService: UserSessionService) {
+  constructor(private readonly transloco: TranslocoService, private readonly userSessionService: UserSessionService) {
     this.setLocale();
   }
 
@@ -29,29 +29,29 @@ export class TableColumnTranslationPipe implements PipeTransform {
     }
   }
 
-  transform(column: any): any {
+  transform(column: unknown): unknown {
     if (typeof column === 'number') {
       return column;
-    } else if (typeof column === 'boolean') {
-      return column ? this.transloco.translate('yes') : this.transloco.translate('no');
-      //Is it a date?
-    } else if (Number.isNaN(Number(column)) && !Number.isNaN(Date.parse(column)) && (column instanceof Date)) {
-      return this.pipe.transform(column, 'short');
-    } else if (column instanceof Object) {
-      return this.transloco.translate(column.toString());
-    } else {
-      if (column) {
-        const text: string = (column as string);
-        if (text.toUpperCase() === text) {
-          //probably is an enum
-          return this.transloco.translate(this.snakeToCamel(text.toLowerCase()));
-        } else {
-          return this.transloco.translate(text);
-        }
-      } else {
-        return "";
-      }
     }
+    if (typeof column === 'boolean') {
+      return column ? this.transloco.translate('yes') : this.transloco.translate('no');
+    }
+    if (column instanceof Date) {
+      return this.pipe.transform(column, 'short');
+    }
+    if (typeof column === 'string' && !Number.isNaN(Date.parse(column))) {
+      return this.pipe.transform(new Date(column), 'short');
+    }
+    if (column === null || column === undefined || column === '') {
+      return "";
+    }
+
+    const text: string = String(column);
+    if (text.toUpperCase() === text) {
+      // probably is an enum
+      return this.transloco.translate(this.snakeToCamel(text.toLowerCase()));
+    }
+    return this.transloco.translate(text);
   }
 
   snakeToCamel(string: string): string {

--- a/frontend/src/app/services/fight.service.ts
+++ b/frontend/src/app/services/fight.service.ts
@@ -1,10 +1,10 @@
 import {Injectable} from '@angular/core';
-import { HttpClient, HttpHeaders } from "@angular/common/http";
+import {HttpClient, HttpHeaders, HttpResponse} from "@angular/common/http";
 import {EnvironmentService} from "../environment.service";
 import {MessageService} from "./message.service";
 import {LoggerService} from "./logger.service";
 import {LoginService} from "./login.service";
-import {Observable, of} from "rxjs";
+import {Observable} from "rxjs";
 import {catchError, map, tap} from "rxjs/operators";
 import {Fight} from "../models/fight";
 import {Tournament} from "../models/tournament";
@@ -26,11 +26,11 @@ import {SystemOverloadService} from "./notifications/system-overload.service";
 })
 export class FightService {
 
-  private baseUrl: string = this.environmentService.getBackendUrl() + '/fights';
+  private readonly baseUrl: string = this.environmentService.getBackendUrl() + '/fights';
 
-  constructor(private http: HttpClient, private environmentService: EnvironmentService, private messageService: MessageService,
-              private loggerService: LoggerService, public loginService: LoginService,
-              private systemOverloadService: SystemOverloadService) {
+  constructor(private readonly http: HttpClient, private readonly environmentService: EnvironmentService, private readonly messageService: MessageService,
+              private readonly loggerService: LoggerService, public loginService: LoginService,
+              private readonly systemOverloadService: SystemOverloadService) {
 
   }
 
@@ -181,12 +181,12 @@ export class FightService {
     const url: string = `${this.baseUrl}` + '/create/tournaments/' + tournamentId + '/next';
     return this.http.put<Fight[]>(url, undefined, {observe: 'response'})
       .pipe(
-        map((response: any) => {
+        map((response: HttpResponse<Fight[]>) => {
           //204 means that fights are not created due to an existing draw score.
           if (response.status === 204) {
-            return of(null);
+            return [];
           }
-          return response.body;
+          return response.body ?? [];
         })
       );
   }

--- a/frontend/src/app/services/logger.service.ts
+++ b/frontend/src/app/services/logger.service.ts
@@ -11,9 +11,9 @@ import {Observable, of} from "rxjs";
 })
 export class LoggerService {
 
-  private baseUrl: string = this.environmentService.getBackendUrl() + '/logger';
+  private readonly baseUrl: string = this.environmentService.getBackendUrl() + '/logger';
 
-  constructor(private http: HttpClient, private environmentService: EnvironmentService, public loginService: LoginService) {
+  constructor(private readonly http: HttpClient, private readonly environmentService: EnvironmentService, public loginService: LoginService) {
   }
 
   info(message: string) {
@@ -23,10 +23,7 @@ export class LoggerService {
   }
 
   sendInfo(log: Log) {
-    const url: string = `${this.baseUrl}/info`;
-    return this.http.post(url, log).pipe(
-      catchError(this.handleErrorConsole('sendInfo'))
-    ).subscribe();
+    return this.sendLog('info', log, 'sendInfo');
   }
 
   warning(message: string) {
@@ -36,10 +33,7 @@ export class LoggerService {
   }
 
   sendWarning(log: Log) {
-    const url: string = `${this.baseUrl}/warning`;
-    return this.http.post(url, log).pipe(
-      catchError(this.handleErrorConsole('sendWarning'))
-    ).subscribe();
+    return this.sendLog('warning', log, 'sendWarning');
   }
 
   error(message: string) {
@@ -49,21 +43,26 @@ export class LoggerService {
   }
 
   sendError(log: Log) {
-    const url: string = `${this.baseUrl}/error`;
+    return this.sendLog('error', log, 'sendError');
+  }
+
+  private sendLog(level: 'info' | 'warning' | 'error', log: Log, operation: string) {
+    const url: string = `${this.baseUrl}/${level}`;
     return this.http.post(url, log).pipe(
-      catchError(this.handleErrorConsole('sendError'))
+      catchError(this.handleErrorConsole(operation))
     ).subscribe();
   }
 
   handleErrorConsole<T>(_operation = 'operation', result?: T) {
-    return (error: any): Observable<T> => {
+    return (_error: unknown): Observable<T> => {
       return of(result as T);
     };
   }
 
   handleError<T>(operation = 'operation', result?: T) {
-    return (error: any): Observable<T> => {
-      this.error(`${operation} failed: ${error.message}`);
+    return (error: unknown): Observable<T> => {
+      const message: string = error instanceof Error ? error.message : String(error);
+      this.error(`${operation} failed: ${message}`);
 
       // Let the app keep running by returning an empty result.
       return of(result as T);

--- a/frontend/src/app/services/login.service.ts
+++ b/frontend/src/app/services/login.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {HttpClient, HttpHeaders} from "@angular/common/http";
+import {HttpClient, HttpHeaders, HttpResponse} from "@angular/common/http";
 import {Observable} from "rxjs";
 import {map, tap} from "rxjs/operators";
 
@@ -36,15 +36,15 @@ import {RbacService} from "./rbac/rbac.service";
 })
 export class LoginService {
 
-  private baseUrl: string = this.environmentService.getBackendUrl() + '/auth';
+  private readonly baseUrl: string = this.environmentService.getBackendUrl() + '/auth';
   static readonly JWT_RENEW_MARGIN: number = 20000;
   private interval: ReturnType<typeof setInterval> | null;
 
-  constructor(private http: HttpClient, private environmentService: EnvironmentService,
-              private activityService: ActivityService, private router: Router, private userSessionService: UserSessionService) {
+  constructor(private readonly http: HttpClient, private readonly environmentService: EnvironmentService,
+              private readonly activityService: ActivityService, private readonly router: Router, private readonly userSessionService: UserSessionService) {
     if (this.getJwtExpirationValue() !== undefined && this.getJwtExpirationValue() > 0) {
-      this.autoRenewToken(this.getJwtValue(), (this.getJwtExpirationValue() - (new Date()).getTime()) - LoginService.JWT_RENEW_MARGIN,
-        (jwt: string, expires: number): void => {
+      this.autoRenewToken(this.getJwtValue(), (this.getJwtExpirationValue() - Date.now()) - LoginService.JWT_RENEW_MARGIN,
+        (): void => {
         });
     }
   }
@@ -57,12 +57,7 @@ export class LoginService {
       observe: 'response'
     })
       .pipe(
-        map((response: any) => {
-          response.body.jwt = response.headers.get('Authorization');
-          response.body.expires = response.headers.get('Expires');
-          response.body.session = response.headers.get('X-Session');
-          return response.body;
-        }));
+        map((response: HttpResponse<AuthenticatedUser>) => this.withAuthHeaders(response)));
   }
 
   loginAsGuest(tournamentId: number): Observable<AuthenticatedUser> {
@@ -73,12 +68,7 @@ export class LoginService {
       observe: 'response'
     })
       .pipe(
-        map((response: any) => {
-          response.body.jwt = response.headers.get('Authorization');
-          response.body.expires = response.headers.get('Expires');
-          response.body.session = response.headers.get('X-Session');
-          return response.body;
-        }));
+        map((response: HttpResponse<AuthenticatedUser>) => this.withAuthHeaders(response)));
   }
 
   loginAsParticipant(temporalToken: string): Observable<AuthenticatedUser> {
@@ -89,12 +79,15 @@ export class LoginService {
       observe: 'response'
     })
       .pipe(
-        map((response: any) => {
-          response.body.jwt = response.headers.get('Authorization');
-          response.body.expires = response.headers.get('Expires');
-          response.body.session = response.headers.get('X-Session');
-          return response.body;
-        }));
+        map((response: HttpResponse<AuthenticatedUser>) => this.withAuthHeaders(response)));
+  }
+
+  private withAuthHeaders(response: HttpResponse<AuthenticatedUser>): AuthenticatedUser {
+    const authenticatedUser: AuthenticatedUser = response.body as AuthenticatedUser;
+    authenticatedUser.jwt = response.headers.get('Authorization') ?? '';
+    authenticatedUser.expires = Number(response.headers.get('Expires') ?? 0);
+    authenticatedUser.session = response.headers.get('X-Session') ?? '';
+    return authenticatedUser;
   }
 
   setGuestUserSession(tournamentId: number, callback: (token: string, expiration: number) => void): void {
@@ -124,7 +117,7 @@ export class LoginService {
 
   setAuthenticatedUser(authenticatedUser: AuthenticatedUser, callback: (token: string, expiration: number) => void): void {
     this.setJwtValue(authenticatedUser.jwt, authenticatedUser.expires);
-    this.autoRenewToken(authenticatedUser.jwt, (authenticatedUser.expires - (new Date()).getTime()) - LoginService.JWT_RENEW_MARGIN,
+    this.autoRenewToken(authenticatedUser.jwt, (authenticatedUser.expires - Date.now()) - LoginService.JWT_RENEW_MARGIN,
       (): void => {
       });
     this.activityService.setRoles(authenticatedUser.roles);
@@ -178,21 +171,21 @@ export class LoginService {
         response => {
           if (!response) {
             console.error('No renew response!!!');
-            this.autoRenewToken(jwt, -1, (jwt: string, expires: number): void => {
+              this.autoRenewToken(jwt, -1, (): void => {
             });
             throw new Error('Server returned no response');
           }
           const authToken: string | null = response.headers.get('Authorization');
           let expiration: number = Number(response.headers.get('Expires'));
           if (!authToken || !expiration) {
-            this.autoRenewToken(jwt, -1, (jwt: string, expires: number): void => {
+            this.autoRenewToken(jwt, -1, (): void => {
             });
             throw new Error('Server returned invalid response');
           }
           if (Number.isNaN(expiration)) {
-            throw new Error('Server returned invalid expiration time');
+            throw new TypeError('Server returned invalid expiration time');
           }
-          const renewValue: number = (expiration - (new Date()).getTime()) - LoginService.JWT_RENEW_MARGIN;
+          const renewValue: number = (expiration - Date.now()) - LoginService.JWT_RENEW_MARGIN;
           callback(authToken, expiration);
           //Set current JWT.
           this.setJwtValue(authToken, expiration);
@@ -212,8 +205,8 @@ export class LoginService {
       );
   }
 
-  private renew(): Observable<any> {
-    return this.http.get<any>(`${this.baseUrl}/jwt/renew`, {observe: 'response'}).pipe(
+  private renew(): Observable<HttpResponse<unknown>> {
+    return this.http.get<unknown>(`${this.baseUrl}/jwt/renew`, {observe: 'response'}).pipe(
       tap({
         next: () => console.info(`Renewing JWT successfully!`)
       })

--- a/frontend/src/app/services/message.service.ts
+++ b/frontend/src/app/services/message.service.ts
@@ -61,11 +61,11 @@ export class MessageService implements OnDestroy {
   }
 
 
-  infoMessage(message: string) {
+  infoMessage(message: string): void {
     this.openSnackBar(message, NotificationType.SUCCESS, this.getDuration(message, 4));
   }
 
-  warningMessage(message: string) {
+  warningMessage(message: string): void {
     this.openSnackBar(message, NotificationType.WARNING, this.getDuration(message, 7));
   }
 
@@ -73,25 +73,24 @@ export class MessageService implements OnDestroy {
     return Math.max((message.length / 15), minDuration);
   }
 
-  errorMessage(message: string) {
+  errorMessage(message: string): void {
     this.openSnackBar(message, NotificationType.ERROR, this.getDuration(message, 10));
   }
 
-  backendErrorMessage(error: number, code: string) {
+  backendErrorMessage(error: number, code: string): void {
     this.openSnackBar(`Error '${error}' with code '${code}' received.`, NotificationType.ERROR, this.getDuration(code, 5));
   }
 
   handleError<T>(operation = 'operation', result?: T) {
-    return (error: any): Observable<T> => {
+    return (error: unknown): Observable<T> => {
+      const errorMessage: string = error instanceof Error ? error.message : String(error ?? '');
       //Log error
       const log: Log = new Log();
-      if (error) {
-        log.message = `${operation} failed: ${error.message}`;
-      }
+      log.message = `${operation} failed: ${errorMessage}`;
       this.loggerService.sendError(log);
 
       //Show error
-      this.errorMessage(`Error connecting to the backend service. ${operation} failed: ${error ? error.message : ""}`);
+      this.errorMessage(`Error connecting to the backend service. ${operation} failed: ${errorMessage}`);
 
       // Let the app keep running by returning an empty result.
       return of(result as T);
@@ -99,10 +98,11 @@ export class MessageService implements OnDestroy {
   }
 
   logOnlyError<T>(operation: string = 'operation', result?: T) {
-    return (error: any): Observable<T> => {
+    return (error: unknown): Observable<T> => {
+      const errorMessage: string = error instanceof Error ? error.message : String(error ?? '');
       //Log error
       const log: Log = new Log();
-      log.message = `${operation} failed: ${error.message}`;
+      log.message = `${operation} failed: ${errorMessage}`;
       this.loggerService.sendError(log);
 
       // Let the app keep running by returning an empty result.

--- a/frontend/src/app/services/user-session.service.ts
+++ b/frontend/src/app/services/user-session.service.ts
@@ -12,23 +12,23 @@ export class UserSessionService {
   private store: boolean;
   private readonly context: string = '';
 
-  constructor(private cookies: CookieService) {
+  constructor(private readonly cookies: CookieService) {
     const authToken: string | null = this.getAuthToken();
     const expires: number | null = this.getLocalAuthExpiration();
 
     const localUserData: string | null = this.getLocalUser();
-    let user: AuthenticatedUser | undefined = localUserData != null ? AuthenticatedUser.clone(
+    let user: AuthenticatedUser | undefined = localUserData !== null ? AuthenticatedUser.clone(
       JSON.parse(localUserData)) : undefined;
     if (!user) {
       const sessionUserData: string | null = this.getSessionUser();
       try {
-        user = sessionUserData != null || sessionUserData != undefined ? AuthenticatedUser.clone(JSON.parse(sessionUserData)) : undefined;
+        user = sessionUserData !== null ? AuthenticatedUser.clone(JSON.parse(sessionUserData)) : undefined;
       } catch (e) {
 
       }
     }
     this.user = user;
-    if (!expires || Number.isNaN(Number(expires)) || expires < new Date().getTime()) {
+    if (!expires || Number.isNaN(Number(expires)) || expires < Date.now()) {
       localStorage.removeItem(`${this.context}.${Constants.SESSION_STORAGE.AUTH_TOKEN}`);
       localStorage.removeItem(`${this.context}.${Constants.SESSION_STORAGE.AUTH_EXPIRATION}`);
       localStorage.removeItem(`${this.context}.${Constants.SESSION_STORAGE.USER}`);
@@ -177,7 +177,7 @@ export class UserSessionService {
 
   isTokenExpired(): boolean {
     const expired: boolean = !sessionStorage.getItem(`${this.context}.${Constants.SESSION_STORAGE.AUTH_EXPIRATION}`) ||
-      new Date().getTime() > +(this.getLocalAuthExpiration() || 0) || !this.getToken();
+      Date.now() > +(this.getLocalAuthExpiration() || 0) || !this.getToken();
     if (!expired) {
       this.loggedIn = true;
     }

--- a/frontend/src/app/services/user.service.ts
+++ b/frontend/src/app/services/user.service.ts
@@ -44,10 +44,10 @@ export class UserService {
     const url: string = `${this.baseUrl}/register`;
     return this.http.get<AuthenticatedUser[]>(url)
       .pipe(
-        map((_users: any) => {
-          for (let user of _users) {
+        map((_users: AuthenticatedUser[]) => {
+          _users.forEach((user: AuthenticatedUser): void => {
             user.roles = UserRoles.getByKeys(user.roles);
-          }
+          });
           return _users;
         }),
         tap({
@@ -67,7 +67,7 @@ export class UserService {
           next: (_authenticatedUser: AuthenticatedUser) => {
             this.loggerService.info(`adding user ${_authenticatedUser}`);
           },
-          error: (error: { status: any; }): void => {
+          error: (error: unknown): void => {
             this.systemOverloadService.isBusy.next(false);
             if (error instanceof HttpErrorResponse) {
               switch (error.status) {
@@ -123,7 +123,6 @@ export class UserService {
           error: () => this.systemOverloadService.isBusy.next(false),
           complete: () => this.systemOverloadService.isBusy.next(false),
         }),
-        //catchError(this.messageService.handleError<void>(`Updating password!`))
       );
   }
 
@@ -151,7 +150,6 @@ export class UserService {
           error: () => this.systemOverloadService.isBusy.next(false),
           complete: () => this.systemOverloadService.isBusy.next(false),
         }),
-        //catchError(this.messageService.handleError<UserRoles[]>(`Roles cannot be retrieved!`))
       );
   }
 }

--- a/frontend/src/app/utils/teams/members.ts
+++ b/frontend/src/app/utils/teams/members.ts
@@ -5,10 +5,10 @@ export function getBalancedMember(_participants: (Participant | undefined)[], se
   const participants: (Participant | undefined)[] = _participants.filter((item: Participant | undefined) => !!item);
   let selected: number = Math.floor(random() * (participants.length / availableSectors));
   let participant: Participant;
-  if (selectFromSector == 0) {
+  if (selectFromSector === 0) {
     participant = participants[selected]!;
     participants.splice(selected, 1);
-  } else if (selectFromSector == availableSectors - 1) {
+  } else if (selectFromSector === availableSectors - 1) {
     selected = participants.length - selected - 1;
     participant = participants[selected]!;
     participants.splice(selected, 1);

--- a/frontend/src/app/views/authenticated-user-list/authenticated-user-list.component.ts
+++ b/frontend/src/app/views/authenticated-user-list/authenticated-user-list.component.ts
@@ -41,20 +41,15 @@ export class AuthenticatedUserListComponent extends RbacBasedComponent implement
 
   protected loading: boolean = false;
 
-  constructor(private userService: UserService, rbacService: RbacService, private systemOverloadService: SystemOverloadService,
-              private userSessionService: UserSessionService, private transloco: TranslocoService,
-              private biitSnackbarService: BiitSnackbarService, private _datePipe: DatePipe) {
+  constructor(private readonly userService: UserService, rbacService: RbacService, private readonly systemOverloadService: SystemOverloadService,
+               private readonly userSessionService: UserSessionService, private readonly transloco: TranslocoService,
+               private readonly biitSnackbarService: BiitSnackbarService, private readonly _datePipe: DatePipe) {
     super(rbacService);
   }
 
   datePipe() {
     return {
-      transform: (value: any) => {
-        if (!value) {
-          value = 0;
-        }
-        return this._datePipe.transform(value, Constants.FORMAT.DATE);
-      }
+      transform: (value: number | string | Date | null | undefined = 0) => this._datePipe.transform(value, Constants.FORMAT.DATE)
     }
   }
 
@@ -94,7 +89,7 @@ export class AuthenticatedUserListComponent extends RbacBasedComponent implement
       next: (_users: AuthenticatedUser[]): void => {
         this.users = _users.map(_user => AuthenticatedUser.clone(_user));
       },
-      error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+      error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
     }).add(() => {
       this.loading = false;
       this.systemOverloadService.isTransactionalBusy.next(false);
@@ -129,7 +124,7 @@ export class AuthenticatedUserListComponent extends RbacBasedComponent implement
             }
           );
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       });
     }
   }

--- a/frontend/src/app/views/club-list/club-list.component.ts
+++ b/frontend/src/app/views/club-list/club-list.component.ts
@@ -39,20 +39,15 @@ export class ClubListComponent extends RbacBasedComponent implements AfterViewIn
   protected confirmDelete: boolean = false;
   protected showRanking: boolean = false;
 
-  constructor(private clubService: ClubService,
-              private transloco: TranslocoService, rbacService: RbacService, private _datePipe: DatePipe,
-              private systemOverloadService: SystemOverloadService, private biitSnackbarService: BiitSnackbarService,) {
+  constructor(private readonly clubService: ClubService,
+              private readonly transloco: TranslocoService, rbacService: RbacService, private readonly _datePipe: DatePipe,
+              private readonly systemOverloadService: SystemOverloadService, private readonly biitSnackbarService: BiitSnackbarService,) {
     super(rbacService);
   }
 
   datePipe() {
     return {
-      transform: (value: any) => {
-        if (!value) {
-          value = 0;
-        }
-        return this._datePipe.transform(value, Constants.FORMAT.DATE);
-      }
+      transform: (value: number | string | Date | null | undefined = 0) => this._datePipe.transform(value, Constants.FORMAT.DATE)
     }
   }
 
@@ -98,7 +93,7 @@ export class ClubListComponent extends RbacBasedComponent implements AfterViewIn
       next: (_clubs: Club[]): void => {
         this.clubs = _clubs.map(_club => Club.clone(_club));
       },
-      error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+      error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
     }).add(() => {
       this.loading = false;
       this.systemOverloadService.isTransactionalBusy.next(false);
@@ -106,8 +101,7 @@ export class ClubListComponent extends RbacBasedComponent implements AfterViewIn
   }
 
   addElement(): void {
-    const club: Club = new Club();
-    this.target = club;
+    this.target = new Club();
   }
 
   editElement(club: Club): void {
@@ -126,7 +120,7 @@ export class ClubListComponent extends RbacBasedComponent implements AfterViewIn
           );
           this.confirmDelete = false;
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       });
     }
   }

--- a/frontend/src/app/views/fight-list/fight-list.component.html
+++ b/frontend/src/app/views/fight-list/fight-list.component.html
@@ -265,7 +265,7 @@
       <competitors-ranking
         [tournament]="tournament"
         [showIndex]="true"
-      (onClosed)="showCompetitorsRanking=false"></competitors-ranking>
+      (closed)="showCompetitorsRanking=false"></competitors-ranking>
     </biit-popup>
   }
 
@@ -304,7 +304,7 @@
   @if (openNewFightPopup) {
     <biit-popup id="fight-creator" closable
       [title]="t('addFight')"
-      (onClosed)="openNewFightPopup=false">
+      (closed)="openNewFightPopup=false">
       <fight-creator
         [tournament]="tournament"
         [previousFight]="this.selectedFight"
@@ -314,14 +314,14 @@
         [swappedTeams]="this.swappedTeams"
         [horizontalTeams]="this.tournament.type === TournamentType.SENBATSU"
         [grid]="this.tournament.type !== TournamentType.SENBATSU"
-      (onClosed)="openNewFightPopup=false"></fight-creator>
+      (closed)="openNewFightPopup=false"></fight-creator>
     </biit-popup>
   }
 
   @if (openSenbatsuFightPopup) {
     <biit-popup id="senbatsu-fight-creator" closable
       [title]="t('addFight')"
-      (onClosed)="openSenbatsuFightPopup=false">
+      (closed)="openSenbatsuFightPopup=false">
       <senbatsu-fight-creator
         [tournament]="tournament"
         [previousFight]="this.selectedFight"
@@ -331,7 +331,7 @@
         [swappedTeams]="this.swappedTeams"
         [horizontalTeams]="this.tournament.type === TournamentType.SENBATSU"
         [grid]="this.tournament.type !== TournamentType.SENBATSU"
-      (onClosed)="openSenbatsuFightPopup=false"></senbatsu-fight-creator>
+      (closed)="openSenbatsuFightPopup=false"></senbatsu-fight-creator>
     </biit-popup>
   }
 
@@ -358,7 +358,7 @@
     <biit-popup id="league-generator-popup" no-header closable>
       <league-generator
         [tournament]="tournament"
-      (onClosed)="createGroupFight($event); openLeagueGeneratorPopup=false"></league-generator>
+      (closed)="createGroupFight($event); openLeagueGeneratorPopup=false"></league-generator>
     </biit-popup>
   }
 </ng-container>

--- a/frontend/src/app/views/fight-list/fight-list.component.ts
+++ b/frontend/src/app/views/fight-list/fight-list.component.ts
@@ -41,7 +41,7 @@ import {FileService} from "../../services/file.service";
 })
 export class FightListComponent extends RbacBasedComponent implements OnInit, OnDestroy {
 
-  private websocketsPrefix: string = this.environmentService.getWebsocketPrefix();
+  private readonly websocketsPrefix: string = this.environmentService.getWebsocketPrefix();
 
   filteredFights: Map<number, Fight[]>;
   filteredUnties: Map<number, Duel[]>;
@@ -110,7 +110,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
     this.filteredUnties = new Map<number, Duel[]>();
     this.filteredLevels = [];
     this.groups = [];
-    const state = this.router.getCurrentNavigation()?.extras.state;
+    const state = this.router.lastSuccessfulNavigation()?.extras.state;
     if (state) {
       //Send by previous view.
       if (state['tournamentId'] && !Number.isNaN(Number(state['tournamentId']))) {
@@ -196,7 +196,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
           }
         }
         if (updatedFights) {
-          this.fightService.updateAll(this.getFights()).subscribe();
+          this.fightService.updateAll(this.getFights()).pipe(takeUntil(this.destroySubject)).subscribe();
         }
       }
       this.systemOverloadService.isTransactionalBusy.next(false);
@@ -204,26 +204,26 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
 
     this.topicSubscription = this.rxStompService.watch(this.websocketsPrefix + '/fights').subscribe((message: Message): void => {
       const messageContent: MessageContent = JSON.parse(message.body);
-      if (messageContent.topic == "Fight" && (!messageContent.session || messageContent.session !== localStorage.getItem('session'))) {
+      if (messageContent.topic === "Fight" && (!messageContent.session || messageContent.session !== localStorage.getItem('session'))) {
         const fight: Fight = JSON.parse(messageContent.payload);
-        if (!messageContent.type || messageContent.type.toLowerCase() == "updated") {
+        if (!messageContent.type || messageContent.type.toLowerCase() === "updated") {
           this.replaceFight(fight);
           if (this.projectorMode) {
             //Remove any finished fight.
             this.resetFilter();
           }
-        } else if (messageContent.type.toLowerCase() == "created") {
+        } else if (messageContent.type.toLowerCase() === "created") {
           this.refreshFights();
         }
       }
     });
 
-    this.topicSubscription = this.rxStompService.watch(this.websocketsPrefix + '/unties').subscribe((message: Message): void => {
+    this.topicSubscription.add(this.rxStompService.watch(this.websocketsPrefix + '/unties').subscribe((message: Message): void => {
       const messageContent: MessageContent = JSON.parse(message.body);
-      if (messageContent.topic == "Duel" && (!messageContent.session || messageContent.session !== localStorage.getItem('session'))) {
+      if (messageContent.topic === "Duel" && (!messageContent.session || messageContent.session !== localStorage.getItem('session'))) {
         this.refreshFights();
       }
-    });
+    }));
   }
 
   updateTeamOrder(fight: Fight, fightReordered: Fight): boolean {
@@ -273,7 +273,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
       //Corrected selected items
       if (this.selectedFight) {
         for (const _group of this.groups) {
-          if (_group.fights.indexOf(this.selectedFight) >= 0) {
+          if (_group.fights.includes(this.selectedFight)) {
             selectedFightIndex = _group.fights.indexOf(this.selectedFight);
           }
         }
@@ -289,7 +289,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
       } else {
         this.selectFight(this.selectedFight);
       }
-      if (this.selectedFight && selectedDuelIndex != undefined && this.selectedFight?.duels[selectedDuelIndex]) {
+      if (this.selectedFight && selectedDuelIndex !== undefined && this.selectedFight?.duels[selectedDuelIndex]) {
         this.selectDuel(this.selectedFight.duels[selectedDuelIndex]);
       }
     }
@@ -334,11 +334,11 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
   }
 
   private getFightsByShiaijo(shiaijo: number): Fight[] {
-    return this.groups.filter(group => group.shiaijo == shiaijo || shiaijo == -1).flatMap((group: Group) => group.fights);
+    return this.groups.filter(group => group.shiaijo === shiaijo || shiaijo === -1).flatMap((group: Group) => group.fights);
   }
 
   private getUntiesByShiaijo(shiaijo: number): Duel[] {
-    return this.groups.filter(group => group.shiaijo == shiaijo || shiaijo == -1).flatMap((group: Group) => group.unties)
+    return this.groups.filter(group => group.shiaijo === shiaijo || shiaijo === -1).flatMap((group: Group) => group.unties)
   }
 
   private refreshFights(): void {
@@ -346,7 +346,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
       this.isWizardEnabled = this.tournament.type !== TournamentType.CUSTOMIZED && this.tournament.type !== TournamentType.CHAMPIONSHIP;
       this.isBracketsEnabled = this.tournament.type === TournamentType.CHAMPIONSHIP;
       if (this.tournamentId) {
-        this.groupService.getFromTournament(this.tournamentId).subscribe((_groups: Group[]): void => {
+        this.groupService.getFromTournament(this.tournamentId).pipe(takeUntil(this.destroySubject)).subscribe((_groups: Group[]): void => {
           if (!_groups) {
             this.messageService.errorMessage('No groups on tournament!');
           } else {
@@ -393,8 +393,8 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
       if (group.level >= showedLevel.length) {
         showedLevel.push(true);
         //Hide level label if it hasn't fights on any of its groups.
-        const groupsOfLevelWithFights: Group[] = sortedGroups.filter((group: Group) => group.level == showedLevel.length - 1 && group.fights.length > 0);
-        if (groupsOfLevelWithFights.length == 0) {
+        const groupsOfLevelWithFights: Group[] = sortedGroups.filter((group: Group) => group.level === showedLevel.length - 1 && group.fights.length > 0);
+        if (groupsOfLevelWithFights.length === 0) {
           showedLevel[showedLevel.length - 1] = false;
         }
       }
@@ -474,7 +474,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
 
   addElement(): void {
     //Ensure that is selected on the typical case.
-    if (this.groups.length == 1) {
+    if (this.groups.length === 1) {
       this.selectedGroup = this.groups[0];
     }
     if (this.selectedGroup) {
@@ -575,7 +575,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
   selectFight(fight: Fight | undefined): void {
     this.selectedFight = fight;
     if (fight) {
-      this.selectedGroup = this.groups.find(group => group.fights.indexOf(fight) >= 0);
+      this.selectedGroup = this.groups.find(group => group.fights.includes(fight));
     } else {
       this.selectedGroup = undefined;
     }
@@ -608,7 +608,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
   }
 
   downloadPDF(): void {
-    if (this.tournament && this.tournament.id) {
+    if (this.tournament?.id) {
       this.fightService.getFightSummaryPDf(this.tournament.id).subscribe((pdf: Blob): void => {
         const blob: Blob = new Blob([pdf], {type: 'application/pdf'});
         const downloadURL: string = window.URL.createObjectURL(blob);
@@ -630,32 +630,30 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
 
   setIpponScores(duel: Duel): void {
     //Put default points.
-    if (duel.competitor1 !== null && duel.competitor2 == null) {
+    if (duel.competitor1 !== null && duel.competitor2 === null) {
       duel.competitor1Score = [];
-      duel.competitor1Score.push(Score.FUSEN_GACHI);
-      duel.competitor1Score.push(Score.FUSEN_GACHI);
-    } else if (duel.competitor2 !== null && duel.competitor1 == null) {
+      duel.competitor1Score.push(Score.FUSEN_GACHI, Score.FUSEN_GACHI);
+    } else if (duel.competitor2 !== null && duel.competitor1 === null) {
       duel.competitor2Score = [];
-      duel.competitor2Score.push(Score.FUSEN_GACHI);
-      duel.competitor2Score.push(Score.FUSEN_GACHI);
+      duel.competitor2Score.push(Score.FUSEN_GACHI, Score.FUSEN_GACHI);
     }
   }
 
   removeIpponScores(duel: Duel): void {
-    for (let i: number = 0; i < duel.competitor1Score.length; i++) {
-      if (duel.competitor1Score[i] == Score.FUSEN_GACHI) {
+    for (const score of duel.competitor1Score) {
+      if (score === Score.FUSEN_GACHI) {
         duel.competitor1Score = [];
       }
     }
-    for (let i: number = 0; i < duel.competitor2Score.length; i++) {
-      if (duel.competitor2Score[i] == Score.FUSEN_GACHI) {
+    for (const score of duel.competitor2Score) {
+      if (score === Score.FUSEN_GACHI) {
         duel.competitor2Score = [];
       }
     }
   }
 
   canStartFight(duel: Duel | undefined): boolean {
-    return duel != undefined && duel?.competitor1 !== null && duel?.competitor2 !== null;
+    return duel !== undefined && duel?.competitor1 !== null && duel?.competitor2 !== null;
   }
 
   finishDuel(): void {
@@ -665,9 +663,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
     if (this.selectedDuel) {
       this.setIpponScores(this.selectedDuel);
       this.selectedDuel.finished = true;
-      if (!this.selectedDuel.finishedAt) {
-        this.selectedDuel.finishedAt = new Date();
-      }
+      this.selectedDuel.finishedAt ??= new Date();
       this.duelService.update(this.selectedDuel).subscribe((): void => {
         this.messageService.infoMessage("infoDuelFinished");
         this.selectedGroup = this.getGroup(this.selectedDuel);
@@ -724,12 +720,12 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
     for (const group of this.groups) {
       for (const fight of group.fights) {
         for (const duel of fight.duels) {
-          if (duel.id == selectedDuel!.id) {
+          if (duel.id === selectedDuel!.id) {
             return group;
           }
         }
         for (const duel of group.unties) {
-          if (duel.id == selectedDuel.id) {
+          if (duel.id === selectedDuel.id) {
             return group;
           }
         }
@@ -772,10 +768,10 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
   finishTournament(date: Date | undefined): void {
     if (!this.tournament.finishedAt && date) {
       this.tournament.finishedAt = date;
-      this.tournamentService.update(this.tournament).subscribe();
+      this.tournamentService.update(this.tournament).pipe(takeUntil(this.destroySubject)).subscribe();
     } else if (!date && this.tournament.finishedAt) {
       this.tournament.finishedAt = undefined
-      this.tournamentService.update(this.tournament).subscribe();
+      this.tournamentService.update(this.tournament).pipe(takeUntil(this.destroySubject)).subscribe();
     }
   }
 
@@ -853,7 +849,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
   updateDuelDuration(duelDuration: number): void {
     if (this.selectedDuel) {
       this.selectedDuel.totalDuration = duelDuration;
-      this.duelService.update(this.selectedDuel).subscribe();
+      this.duelService.update(this.selectedDuel).pipe(takeUntil(this.destroySubject)).subscribe();
     }
   }
 
@@ -861,7 +857,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
     if (this.selectedDuel) {
       this.selectedDuel.duration = elapsedTime;
       if (updateBackend) {
-        this.duelService.update(this.selectedDuel).subscribe();
+        this.duelService.update(this.selectedDuel).pipe(takeUntil(this.destroySubject)).subscribe();
       }
     }
   }
@@ -870,12 +866,12 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
     if (this.selectedDuel && !this.selectedDuel.duration && !this.selectedDuel.startedAt) {
       this.selectedDuel.duration = elapsedTime;
       this.selectedDuel.startedAt = new Date();
-      this.duelService.update(this.selectedDuel).subscribe();
+      this.duelService.update(this.selectedDuel).pipe(takeUntil(this.destroySubject)).subscribe();
     }
   }
 
   showSelectedRelatedButton(): boolean {
-    return !(this.selectedFight !== undefined || (this.selectedDuel !== undefined && this.selectedDuel.type === DuelType.UNDRAW));
+    return !(this.selectedFight !== undefined || this.selectedDuel?.type === DuelType.UNDRAW);
   }
 
   swapColors(): void {
@@ -903,7 +899,7 @@ export class FightListComponent extends RbacBasedComponent implements OnInit, On
       if (group.fights) {
         this.filteredFights.set(group.id!, group.fights.filter((_fight: Fight) =>
           _fight != null &&
-          (this.selectedShiaijo < 0 || _fight.shiaijo == this.selectedShiaijo) &&
+          (this.selectedShiaijo < 0 || _fight.shiaijo === this.selectedShiaijo) &&
           (!this.hideFinishedFights || !this.isFightOver(_fight)) &&
           ((_fight.team1 ? _fight.team1.name.normalize('NFD').replace(/\p{Diacritic}/gu, "").toLowerCase().includes(filter) : "") ||
             (_fight.team2 ? _fight.team2.name.normalize('NFD').replace(/\p{Diacritic}/gu, "").toLowerCase().includes(filter) : "") ||

--- a/frontend/src/app/views/fight-list/league-generator/league-generator.component.ts
+++ b/frontend/src/app/views/fight-list/league-generator/league-generator.component.ts
@@ -20,6 +20,8 @@ import {Participant} from "../../../models/participant";
 import {ScoreOfCompetitor} from "../../../models/score-of-competitor";
 import {RankingService} from "../../../services/ranking.service";
 import {BiitProgressBarType} from "@biit-solutions/wizardry-theme/info";
+import {takeUntil} from "rxjs";
+import {random} from "../../../utils/random/random";
 
 @Component({
   standalone: false,
@@ -32,7 +34,7 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
   @Input()
   tournament: Tournament;
   @Output()
-  onClosed: EventEmitter<Team[]> = new EventEmitter<Team[]>();
+  closed: EventEmitter<Team[]> = new EventEmitter<Team[]>();
 
   teamListData: TeamListData = new TeamListData();
   teams: Team[];
@@ -57,9 +59,9 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
 
   protected openExtraProperties: boolean = false;
 
-  constructor(private teamService: TeamService, rbacService: RbacService,
-              private tournamentExtendedPropertiesService: TournamentExtendedPropertiesService,
-              private messageService: MessageService, private rankingService: RankingService) {
+  constructor(private readonly teamService: TeamService, rbacService: RbacService,
+              private readonly tournamentExtendedPropertiesService: TournamentExtendedPropertiesService,
+              private readonly messageService: MessageService, private readonly rankingService: RankingService) {
     super(rbacService);
     this.defaultPropertiesValue();
   }
@@ -67,7 +69,7 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
   private initTournament(): void {
     if (this.tournament.type === TournamentType.KING_OF_THE_MOUNTAIN) {
       this.drawResolution = DrawResolution.toArray();
-    } else if (TournamentType.BUBBLE_SORT) {
+    } else if (this.tournament.type === TournamentType.BUBBLE_SORT) {
       this.drawResolution = [DrawResolution.OLDEST_ELIMINATED, DrawResolution.NEWEST_ELIMINATED];
     } else {
       this.drawResolution = [];
@@ -82,24 +84,24 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
   ngOnInit(): void {
     this.initTournament();
     if (this.canMaximizeFights || this.needsDrawResolution || this.needsFifoWinner) {
-      this.tournamentExtendedPropertiesService.getByTournament(this.tournament).subscribe((_tournamentSelection: TournamentExtendedProperty[]): void => {
+      this.tournamentExtendedPropertiesService.getByTournament(this.tournament).pipe(takeUntil(this.destroySubject)).subscribe((_tournamentSelection: TournamentExtendedProperty[]): void => {
         if (_tournamentSelection) {
           for (const _tournamentProperty of _tournamentSelection) {
-            if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.KING_DRAW_RESOLUTION) {
+            if (_tournamentProperty.propertyKey === TournamentExtraPropertyKey.KING_DRAW_RESOLUTION) {
               this.selectedDrawResolution = DrawResolution.getByKey(_tournamentProperty.propertyValue);
             }
-            if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.MAXIMIZE_FIGHTS) {
-              this.areFightsMaximized = (_tournamentProperty.propertyValue.toLowerCase() == "true");
+            if (_tournamentProperty.propertyKey === TournamentExtraPropertyKey.MAXIMIZE_FIGHTS) {
+              this.areFightsMaximized = (_tournamentProperty.propertyValue.toLowerCase() === "true");
             }
-            if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.LEAGUE_FIGHTS_ORDER_GENERATION) {
-              this.firstInFirstOut = (_tournamentProperty.propertyValue.toUpperCase() == LeagueFightsOrder.FIFO);
+            if (_tournamentProperty.propertyKey === TournamentExtraPropertyKey.LEAGUE_FIGHTS_ORDER_GENERATION) {
+              this.firstInFirstOut = (_tournamentProperty.propertyValue.toUpperCase() === LeagueFightsOrder.FIFO);
             }
           }
         }
       });
     }
 
-    this.teamService.getFromTournament(this.tournament).subscribe((_teams: Team[]): void => {
+    this.teamService.getFromTournament(this.tournament).pipe(takeUntil(this.destroySubject)).subscribe((_teams: Team[]): void => {
       if (_teams) {
         _teams.sort(function (a: Team, b: Team) {
           return a.name.localeCompare(b.name);
@@ -109,12 +111,12 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
       this.teamListData.teams = _teams;
       this.teamListData.filteredTeams = _teams;
     });
-    this.avoidDuplicates.valueChanges.subscribe(avoidDuplicates => {
+    this.avoidDuplicates.valueChanges.pipe(takeUntil(this.destroySubject)).subscribe(avoidDuplicates => {
       const tournamentProperty: TournamentExtendedProperty = new TournamentExtendedProperty();
       tournamentProperty.tournament = this.tournament;
       tournamentProperty.propertyValue = !avoidDuplicates + "";
       tournamentProperty.propertyKey = TournamentExtraPropertyKey.MAXIMIZE_FIGHTS;
-      this.tournamentExtendedPropertiesService.update(tournamentProperty).subscribe((): void => {
+      this.tournamentExtendedPropertiesService.update(tournamentProperty).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
         this.messageService.infoMessage('infoTournamentUpdated');
       });
     });
@@ -128,11 +130,11 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
   }
 
   acceptAction() {
-    this.onClosed.emit(this.teamsOrder);
+    this.closed.emit(this.teamsOrder);
   }
 
   cancelDialog() {
-    this.onClosed.emit([]);
+    this.closed.emit([]);
   }
 
   private transferCard(event: CdkDragDrop<Team[], any>): Team {
@@ -185,7 +187,7 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
   }
 
   getRandomTeam(teams: Team[]): Team {
-    const selected: number = Math.floor(Math.random() * teams.length);
+    const selected: number = Math.floor(random() * teams.length);
     const team: Team = teams[selected];
     teams.splice(selected, 1);
     return team;
@@ -194,7 +196,7 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
   balancedTeams(): void {
     let participants: (Participant | undefined)[] = this.teams.flatMap((team: Team) => team.members);
 
-    this.rankingService.getCompetitorsGlobalScoreRanking(participants, undefined).subscribe((_scoreRanking: ScoreOfCompetitor[]): void => {
+    this.rankingService.getCompetitorsGlobalScoreRanking(participants, undefined).pipe(takeUntil(this.destroySubject)).subscribe((_scoreRanking: ScoreOfCompetitor[]): void => {
       const sortedParticipants: Participant[] = _scoreRanking.map((scoreOfCompetitor: ScoreOfCompetitor) => scoreOfCompetitor.competitor);
       //Get Teams classification by members index.
       const teamsScore: Map<number, Team> = new Map();
@@ -220,14 +222,16 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
       this.teamsOrder.push(...sortedTeams.values());
       this.teamListData.teams = [];
       this.teamListData.filteredTeams = [];
-      if (this.tournament.type == TournamentType.SENBATSU) {
-        this.teamsOrder = this.teamsOrder.reverse();
+      if (this.tournament.type === TournamentType.SENBATSU) {
+        const reversedTeams: Team[] = [...this.teamsOrder].reverse();
+        this.teamsOrder = reversedTeams;
       }
     });
   }
 
   reverseTeams(): void {
-    this.teamsOrder = this.teamsOrder.reverse();
+    const reversedTeams: Team[] = [...this.teamsOrder].reverse();
+    this.teamsOrder = reversedTeams;
   }
 
 
@@ -250,7 +254,7 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
     tournamentProperty.tournament = this.tournament;
     tournamentProperty.propertyValue = $event.checked + "";
     tournamentProperty.propertyKey = TournamentExtraPropertyKey.MAXIMIZE_FIGHTS;
-    this.tournamentExtendedPropertiesService.update(tournamentProperty).subscribe((): void => {
+    this.tournamentExtendedPropertiesService.update(tournamentProperty).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
       this.messageService.infoMessage('infoTournamentUpdated');
     });
   }
@@ -261,7 +265,7 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
     tournamentProperty.tournament = this.tournament;
     tournamentProperty.propertyValue = drawResolution;
     tournamentProperty.propertyKey = TournamentExtraPropertyKey.KING_DRAW_RESOLUTION;
-    this.tournamentExtendedPropertiesService.update(tournamentProperty).subscribe((): void => {
+    this.tournamentExtendedPropertiesService.update(tournamentProperty).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
       this.messageService.infoMessage('infoTournamentUpdated');
     });
   }
@@ -271,7 +275,7 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
     tournamentProperty.tournament = this.tournament;
     tournamentProperty.propertyValue = $event.checked ? LeagueFightsOrder.FIFO : LeagueFightsOrder.LIFO;
     tournamentProperty.propertyKey = TournamentExtraPropertyKey.LEAGUE_FIGHTS_ORDER_GENERATION;
-    this.tournamentExtendedPropertiesService.update(tournamentProperty).subscribe((): void => {
+    this.tournamentExtendedPropertiesService.update(tournamentProperty).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
       this.messageService.infoMessage('infoTournamentUpdated');
     });
   }
@@ -281,7 +285,7 @@ export class LeagueGeneratorComponent extends RbacBasedComponent implements OnIn
     tournamentProperty.tournament = this.tournament;
     tournamentProperty.propertyValue = $event.checked + "";
     tournamentProperty.propertyKey = TournamentExtraPropertyKey.AVOID_DUPLICATES;
-    this.tournamentExtendedPropertiesService.update(tournamentProperty).subscribe((): void => {
+    this.tournamentExtendedPropertiesService.update(tournamentProperty).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
       this.messageService.infoMessage('infoTournamentUpdated');
     });
   }

--- a/frontend/src/app/views/fight-list/tournament-generator/tournament-generator.component.ts
+++ b/frontend/src/app/views/fight-list/tournament-generator/tournament-generator.component.ts
@@ -21,6 +21,7 @@ import {
   TournamentChangedService
 } from "../../../components/tournament-brackets-editor/tournament-brackets/tournament-changed.service";
 import {BiitProgressBarType} from "@biit-solutions/wizardry-theme/info";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -47,13 +48,13 @@ export class TournamentGeneratorComponent extends RbacBasedComponent implements 
   protected generateGroupConfirmation: boolean = false;
   loadingGlobal: boolean = false;
 
-  constructor(private router: Router, rbacService: RbacService, private tournamentService: TournamentService,
-              private fightService: FightService, private messageService: MessageService,
-              private groupService: GroupService, private tournamentChangedService: TournamentChangedService,
-              private tournamentExtendedPropertiesService: TournamentExtendedPropertiesService,
-              private numberOfWinnersUpdatedService: NumberOfWinnersUpdatedService) {
+  constructor(private readonly router: Router, rbacService: RbacService, private readonly tournamentService: TournamentService,
+              private readonly fightService: FightService, private readonly messageService: MessageService,
+              private readonly groupService: GroupService, private readonly tournamentChangedService: TournamentChangedService,
+              private readonly tournamentExtendedPropertiesService: TournamentExtendedPropertiesService,
+              private readonly numberOfWinnersUpdatedService: NumberOfWinnersUpdatedService) {
     super(rbacService);
-    const state = this.router.getCurrentNavigation()?.extras.state;
+    const state = this.router.lastSuccessfulNavigation()?.extras.state;
     if (state) {
       if (state['tournamentId'] && !Number.isNaN(Number(state['tournamentId']))) {
         this.tournamentId = Number(state['tournamentId']);
@@ -67,7 +68,7 @@ export class TournamentGeneratorComponent extends RbacBasedComponent implements 
   }
 
   ngOnInit(): void {
-    this.tournamentService.get(this.tournamentId).subscribe((tournament: Tournament): void => {
+    this.tournamentService.get(this.tournamentId).pipe(takeUntil(this.destroySubject)).subscribe((tournament: Tournament): void => {
       this.tournament = tournament;
       this.tournamentChangedService.isTournamentChanged.next(tournament);
       this.refreshWinner();
@@ -94,7 +95,7 @@ export class TournamentGeneratorComponent extends RbacBasedComponent implements 
 
   generateElements(): void {
     this.loadingGlobal = true;
-    this.fightService.create(this.tournamentId, 0).subscribe((fights: Fight[]): void => {
+    this.fightService.create(this.tournamentId, 0).pipe(takeUntil(this.destroySubject)).subscribe((fights: Fight[]): void => {
       this.messageService.infoMessage("infoFightCreated");
       this.goBackToFights();
     }).add(() => this.loadingGlobal = false);
@@ -107,7 +108,8 @@ export class TournamentGeneratorComponent extends RbacBasedComponent implements 
     });
   }
 
-  groupsActionsDisabled(disabled: boolean) {
+  groupsActionsDisabled(_disabled: boolean): void {
+    void _disabled;
     this.updatingGroup = false;
   }
 
@@ -117,7 +119,7 @@ export class TournamentGeneratorComponent extends RbacBasedComponent implements 
 
   downloadPDF(): void {
     if (this.tournament?.id) {
-      this.groupService.getGroupsByTournament(this.tournament.id).subscribe((pdf: Blob): void => {
+      this.groupService.getGroupsByTournament(this.tournament.id).pipe(takeUntil(this.destroySubject)).subscribe((pdf: Blob): void => {
         const blob: Blob = new Blob([pdf], {type: 'application/pdf'});
         const downloadURL: string = window.URL.createObjectURL(blob);
 
@@ -130,16 +132,16 @@ export class TournamentGeneratorComponent extends RbacBasedComponent implements 
   }
 
   private refreshWinner(): void {
-    if (this.tournament.type == TournamentType.CHAMPIONSHIP) {
-      this.tournamentExtendedPropertiesService.getByTournament(this.tournament).subscribe((_tournamentSelection: TournamentExtendedProperty[]): void => {
+    if (this.tournament.type === TournamentType.CHAMPIONSHIP) {
+      this.tournamentExtendedPropertiesService.getByTournament(this.tournament).pipe(takeUntil(this.destroySubject)).subscribe((_tournamentSelection: TournamentExtendedProperty[]): void => {
         if (_tournamentSelection) {
           for (const _tournamentProperty of _tournamentSelection) {
-            if (_tournamentProperty.propertyKey == TournamentExtraPropertyKey.NUMBER_OF_WINNERS) {
-              this.numberOfWinners = Number(_tournamentProperty.propertyValue.toLowerCase());
+            if (_tournamentProperty.propertyKey === TournamentExtraPropertyKey.NUMBER_OF_WINNERS) {
+              this.numberOfWinners ??= Number(_tournamentProperty.propertyValue.toLowerCase());
             }
           }
         }
-        if (this.numberOfWinners == undefined) {
+        if (this.numberOfWinners === undefined) {
           this.numberOfWinners = 1;
         }
       });
@@ -153,15 +155,15 @@ export class TournamentGeneratorComponent extends RbacBasedComponent implements 
     tournamentProperty.tournament = this.tournament;
     tournamentProperty.propertyValue = numberOfWinners + "";
     tournamentProperty.propertyKey = TournamentExtraPropertyKey.NUMBER_OF_WINNERS;
-    this.tournamentService.setNumberOfWinners(this.tournament, numberOfWinners).subscribe((): void => {
+    this.tournamentService.setNumberOfWinners(this.tournament, numberOfWinners).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
       this.numberOfWinnersUpdatedService.numberOfWinners.next(numberOfWinners);
       this.messageService.infoMessage('infoTournamentUpdated');
     });
   }
 
-  refreshGroups() {
+  refreshGroups(): void {
     this.loadingGlobal = true;
-    this.groupService.refreshNonStartedGroups(this.tournamentId, 1).subscribe((): void => {
+    this.groupService.refreshNonStartedGroups(this.tournamentId, 1).pipe(takeUntil(this.destroySubject)).subscribe((): void => {
       this.tournamentBracketsEditorComponent.updateData(true, true);
     }).add(() => this.loadingGlobal = false);
   }

--- a/frontend/src/app/views/participant-list/participant-form-popup/participant-form-popup.component.ts
+++ b/frontend/src/app/views/participant-list/participant-form-popup/participant-form-popup.component.ts
@@ -25,45 +25,36 @@ export class ParticipantFormPopupComponent implements OnInit {
   @Input() participant: Participant;
   @Output() closed: EventEmitter<void> = new EventEmitter<void>();
   @Output() saved: EventEmitter<Participant> = new EventEmitter<Participant>();
-  @Output() errorEvent: EventEmitter<any> = new EventEmitter<any>();
+  @Output() errorEvent: EventEmitter<unknown> = new EventEmitter<unknown>();
 
   protected readonly RbacActivity = RbacActivity;
 
   protected errors: Map<ParticipantFormValidationFields, string> = new Map<ParticipantFormValidationFields, string>();
   protected loggedUser: AuthenticatedUser | undefined;
 
-  constructor(protected sessionService: UserSessionService, private csvService: CsvService,
-              private biitSnackbarService: BiitSnackbarService, protected transloco: TranslocoService) {
+  constructor(protected sessionService: UserSessionService, private readonly csvService: CsvService,
+              private readonly biitSnackbarService: BiitSnackbarService, protected transloco: TranslocoService) {
   }
 
   ngOnInit(): void {
     this.loggedUser = this.sessionService.getUser();
   }
 
-  handleFileInput(event: Event) {
-    const element = event.currentTarget as HTMLInputElement;
-    let fileList: FileList | null = element.files;
-    if (fileList) {
-      const file: File | null = fileList.item(0);
-      if (file) {
-        this.csvService.addParticipants(file).subscribe(_participants => {
-          if (_participants.length == 0) {
-            this.transloco.selectTranslate('infoParticipantStored').subscribe(
-              translation => {
-                this.biitSnackbarService.showNotification(translation, NotificationType.SUCCESS);
-              }
-            );
-            this.saved.emit();
-          } else {
-            const parameters: object = {element: _participants[0].name};
-            this.transloco.selectTranslate('failedOnCsvField', parameters).subscribe(
-              translation => {
-                this.biitSnackbarService.showNotification(translation, NotificationType.ERROR);
-              }
-            );
-          }
-        });
-      }
+  handleFileInput(event: Event): void {
+    const element: HTMLInputElement = event.currentTarget as HTMLInputElement;
+    const file: File | null | undefined = element.files?.item(0);
+    if (!file) {
+      return;
     }
+
+    this.csvService.addParticipants(file).subscribe(_participants => {
+      if (_participants.length === 0) {
+        this.biitSnackbarService.showNotification(this.transloco.translate('infoParticipantStored'), NotificationType.SUCCESS);
+        this.saved.emit();
+      } else {
+        const parameters: object = {element: _participants[0].name};
+        this.biitSnackbarService.showNotification(this.transloco.translate('failedOnCsvField', parameters), NotificationType.ERROR);
+      }
+    });
   }
 }

--- a/frontend/src/app/views/participant-list/participant-list.component.ts
+++ b/frontend/src/app/views/participant-list/participant-list.component.ts
@@ -11,7 +11,7 @@ import {UserSessionService} from "../../services/user-session.service";
 import {CustomDatePipe} from "../../pipes/visualization/custom-date-pipe";
 import {DatePipe} from "@angular/common";
 import {DatatableColumn} from "@biit-solutions/wizardry-theme/table";
-import {combineLatest} from "rxjs";
+import {combineLatest, takeUntil} from "rxjs";
 import {SystemOverloadService} from "../../services/notifications/system-overload.service";
 import {ErrorHandler} from "@biit-solutions/wizardry-theme/utils";
 import {BiitSnackbarService, NotificationType} from "@biit-solutions/wizardry-theme/info";
@@ -36,10 +36,10 @@ export class ParticipantListComponent extends RbacBasedComponent implements Afte
   protected columns: DatatableColumn[] = [];
   protected pageSize: number = 10;
   protected pageSizes: number[] = [10, 25, 50, 100];
-  protected participants: Participant[];
-  protected target: Participant | null;
+  protected participants: Participant[] = [];
+  protected target: Participant | null = null;
   protected confirmDelete: boolean = false;
-  clubs: Club[];
+  clubs: Club[] = [];
 
   protected loading: boolean = false;
   protected showQr: boolean = false;
@@ -48,21 +48,19 @@ export class ParticipantListComponent extends RbacBasedComponent implements Afte
 
   protected readonly port: number = +globalThis.location.port;
 
-  constructor(private router: Router, private userSessionService: UserSessionService,
-              private participantService: ParticipantService,
-              private clubService: ClubService, private transloco: TranslocoService, rbacService: RbacService,
-              private _datePipe: DatePipe, private _clubNamePipe: ClubNamePipe,
-              private systemOverloadService: SystemOverloadService, private biitSnackbarService: BiitSnackbarService,) {
+  constructor(private readonly router: Router, private readonly userSessionService: UserSessionService,
+              private readonly participantService: ParticipantService,
+              private readonly clubService: ClubService, private readonly transloco: TranslocoService, rbacService: RbacService,
+              private readonly _datePipe: DatePipe, private readonly _clubNamePipe: ClubNamePipe,
+              private readonly systemOverloadService: SystemOverloadService, private readonly biitSnackbarService: BiitSnackbarService,) {
     super(rbacService);
   }
 
-  datePipe() {
+  datePipe(): { transform: (value: number | string | Date | null | undefined) => string | null } {
     return {
-      transform: (value: any) => {
-        if (!value) {
-          value = 0;
-        }
-        return this._datePipe.transform(value, Constants.FORMAT.DATE);
+      transform: (value: number | string | Date | null | undefined) => {
+        const normalizedValue: number | string | Date = value ?? 0;
+        return this._datePipe.transform(normalizedValue, Constants.FORMAT.DATE);
       }
     }
   }
@@ -80,7 +78,7 @@ export class ParticipantListComponent extends RbacBasedComponent implements Afte
         this.transloco.selectTranslate('updatedBy'),
         this.transloco.selectTranslate('updatedAt'),
       ]
-    ).subscribe(([id, idCard, name, lastname, clubName, createdBy, createdAt, updatedBy, updatedAt]) => {
+    ).pipe(takeUntil(this.destroySubject)).subscribe(([id, idCard, name, lastname, clubName, createdBy, createdAt, updatedBy, updatedAt]) => {
       this.columns = [
         new DatatableColumn(id, 'id', false, 80),
         new DatatableColumn(idCard, 'idCard', false),
@@ -99,7 +97,7 @@ export class ParticipantListComponent extends RbacBasedComponent implements Afte
   loadData(): void {
     this.loading = true;
     this.systemOverloadService.isTransactionalBusy.next(true);
-    this.clubService.getAll().subscribe((_clubs: Club[]): void => {
+    this.clubService.getAll().pipe(takeUntil(this.destroySubject)).subscribe((_clubs: Club[]): void => {
       if (_clubs) {
         _clubs.sort(function (a: Club, b: Club) {
           return a.name.localeCompare(b.name);
@@ -107,11 +105,11 @@ export class ParticipantListComponent extends RbacBasedComponent implements Afte
         this.clubs = _clubs
       }
     });
-    this.participantService.getAll().subscribe({
+    this.participantService.getAll().pipe(takeUntil(this.destroySubject)).subscribe({
       next: (_participants: Participant[]): void => {
         this.participants = _participants.map(_participant => Participant.clone(_participant));
       },
-      error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+      error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
     }).add(() => {
       this.loading = false;
       this.systemOverloadService.isTransactionalBusy.next(false);
@@ -128,17 +126,13 @@ export class ParticipantListComponent extends RbacBasedComponent implements Afte
 
   deleteElements(participants: Participant[]): void {
     if (participants) {
-      combineLatest(participants.map(participant => this.participantService.delete(participant))).subscribe({
+      combineLatest(participants.map(participant => this.participantService.delete(participant))).pipe(takeUntil(this.destroySubject)).subscribe({
         next: (): void => {
           this.loadData();
-          this.transloco.selectTranslate('infoParticipantDeleted').subscribe(
-            translation => {
-              this.biitSnackbarService.showNotification(translation, NotificationType.SUCCESS);
-            }
-          );
+          this.biitSnackbarService.showNotification(this.transloco.translate('infoParticipantDeleted'), NotificationType.SUCCESS);
           this.confirmDelete = false;
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+        error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       });
     }
   }
@@ -150,7 +144,8 @@ export class ParticipantListComponent extends RbacBasedComponent implements Afte
     }
   }
 
-  onSaved($event: Participant) {
+  onSaved(savedParticipant?: Participant): void {
+    void savedParticipant;
     this.biitSnackbarService.showNotification(this.transloco.translate('infoParticipantStored'), NotificationType.INFO);
     this.loadData();
     this.target = null;

--- a/frontend/src/app/views/tournament-list/tournament-form-popup/tournament-images/tournament-images.component.html
+++ b/frontend/src/app/views/tournament-list/tournament-form-popup/tournament-images/tournament-images.component.html
@@ -185,7 +185,7 @@
     </biit-tab>
   </biit-tab-group>
   <div class="buttons-row">
-    <button biit-button id="tournament-button-save" primary (click)="onClosed.emit()">
+    <button biit-button id="tournament-button-save" primary (click)="closed.emit()">
       {{ t('close') }}
     </button>
   </div>

--- a/frontend/src/app/views/tournament-list/tournament-form-popup/tournament-images/tournament-images.component.ts
+++ b/frontend/src/app/views/tournament-list/tournament-form-popup/tournament-images/tournament-images.component.ts
@@ -13,6 +13,7 @@ import {TournamentImageType} from "../../../../models/tournament-image-type";
 import {TranslocoService} from '@jsverse/transloco';
 import {Participant} from "../../../../models/participant";
 import {TournamentService} from "../../../../services/tournament.service";
+import {takeUntil} from "rxjs";
 
 @Component({
   standalone: false,
@@ -23,7 +24,7 @@ import {TournamentService} from "../../../../services/tournament.service";
 export class TournamentImagesComponent extends RbacBasedComponent implements OnInit {
   @Input()
   tournament: Tournament;
-  @Output() onClosed: EventEmitter<void> = new EventEmitter<void>();
+  @Output() closed: EventEmitter<void> = new EventEmitter<void>();
   protected readonly BiitProgressBarType = BiitProgressBarType;
   protected loading: boolean = false;
   protected diplomaImage: string | null;
@@ -37,7 +38,7 @@ export class TournamentImagesComponent extends RbacBasedComponent implements OnI
 
   constructor(rbacService: RbacService,
               public messageService: MessageService, public fileService: FileService, public transloco: TranslocoService,
-              private tournamentExtendedPropertiesService: TournamentExtendedPropertiesService, private tournamentService: TournamentService) {
+              private readonly tournamentExtendedPropertiesService: TournamentExtendedPropertiesService, private readonly tournamentService: TournamentService) {
     super(rbacService);
   }
 
@@ -57,15 +58,15 @@ export class TournamentImagesComponent extends RbacBasedComponent implements OnI
       } else {
         const imageCompression: ImageCompression | undefined = ImageCompression.getByType(file.type);
         if (imageCompression) {
-          this.fileService.setTournamentFilePicture(file, this.tournament, tournamentImageType, imageCompression).subscribe(_picture => {
+          this.fileService.setTournamentFilePicture(file, this.tournament, tournamentImageType, imageCompression).pipe(takeUntil(this.destroySubject)).subscribe(_picture => {
             this.messageService.infoMessage('infoPictureStored');
-            if (tournamentImageType == TournamentImageType.ACCREDITATION) {
+            if (tournamentImageType === TournamentImageType.ACCREDITATION) {
               this.accreditationImage = _picture.base64;
-            } else if (tournamentImageType == TournamentImageType.BANNER) {
+            } else if (tournamentImageType === TournamentImageType.BANNER) {
               this.bannerImage = _picture.base64;
-            } else if (tournamentImageType == TournamentImageType.DIPLOMA) {
+            } else if (tournamentImageType === TournamentImageType.DIPLOMA) {
               this.diplomaImage = _picture.base64;
-            } else if (tournamentImageType == TournamentImageType.PHOTO) {
+            } else if (tournamentImageType === TournamentImageType.PHOTO) {
               this.defaultPhotoImage = _picture.base64;
             }
           });
@@ -77,10 +78,10 @@ export class TournamentImagesComponent extends RbacBasedComponent implements OnI
   }
 
   private refreshNameLine() {
-    this.tournamentExtendedPropertiesService.getByTournamentAndKey(this.tournament, TournamentExtraPropertyKey.DIPLOMA_NAME_HEIGHT).subscribe(_tournamentProperty => {
+    this.tournamentExtendedPropertiesService.getByTournamentAndKey(this.tournament, TournamentExtraPropertyKey.DIPLOMA_NAME_HEIGHT).pipe(takeUntil(this.destroySubject)).subscribe(_tournamentProperty => {
       if (_tournamentProperty) {
-        this.nameLine = parseFloat(_tournamentProperty.propertyValue) * 100;
-        if (this.nameLine == 0) {
+        this.nameLine = Number.parseFloat(_tournamentProperty.propertyValue) * 100;
+        if (this.nameLine === 0) {
           this.nameLine = this.componentHeight / 2;
         }
       } else {
@@ -90,28 +91,28 @@ export class TournamentImagesComponent extends RbacBasedComponent implements OnI
   }
 
   private refreshImages() {
-    this.fileService.getTournamentPicture(this.tournament, TournamentImageType.DIPLOMA).subscribe(_picture => {
+    this.fileService.getTournamentPicture(this.tournament, TournamentImageType.DIPLOMA).pipe(takeUntil(this.destroySubject)).subscribe(_picture => {
       if (_picture) {
         this.diplomaImage = _picture.base64;
       } else {
         this.diplomaImage = null;
       }
     });
-    this.fileService.getTournamentPicture(this.tournament, TournamentImageType.BANNER).subscribe(_picture => {
+    this.fileService.getTournamentPicture(this.tournament, TournamentImageType.BANNER).pipe(takeUntil(this.destroySubject)).subscribe(_picture => {
       if (_picture) {
         this.bannerImage = _picture.base64;
       } else {
         this.bannerImage = null;
       }
     });
-    this.fileService.getTournamentPicture(this.tournament, TournamentImageType.PHOTO).subscribe(_picture => {
+    this.fileService.getTournamentPicture(this.tournament, TournamentImageType.PHOTO).pipe(takeUntil(this.destroySubject)).subscribe(_picture => {
       if (_picture) {
         this.defaultPhotoImage = _picture.base64;
       } else {
         this.defaultPhotoImage = null;
       }
     });
-    this.fileService.getTournamentPicture(this.tournament, TournamentImageType.ACCREDITATION).subscribe(_picture => {
+    this.fileService.getTournamentPicture(this.tournament, TournamentImageType.ACCREDITATION).pipe(takeUntil(this.destroySubject)).subscribe(_picture => {
       if (_picture) {
         this.accreditationImage = _picture.base64;
       } else {
@@ -155,13 +156,25 @@ export class TournamentImagesComponent extends RbacBasedComponent implements OnI
     tournamentProperty.tournament = this.tournament;
     tournamentProperty.propertyValue = (this.nameLine / 100).toString();
     tournamentProperty.propertyKey = TournamentExtraPropertyKey.DIPLOMA_NAME_HEIGHT;
-    this.tournamentExtendedPropertiesService.update(tournamentProperty).subscribe();
+    this.tournamentExtendedPropertiesService.update(tournamentProperty).pipe(takeUntil(this.destroySubject)).subscribe();
   }
 
   deletePicture(imageType: TournamentImageType) {
-    this.fileService.deleteTournamentPicture(this.tournament, imageType).subscribe(_picture => {
+    this.fileService.deleteTournamentPicture(this.tournament, imageType).pipe(takeUntil(this.destroySubject)).subscribe(_picture => {
       this.messageService.infoMessage('pictureDeleted');
       this.refreshImages();
+    });
+  }
+
+  private downloadPdfPreview(pdf$: import("rxjs").Observable<Blob>, fileName: string): void {
+    pdf$.pipe(takeUntil(this.destroySubject)).subscribe((html: Blob) => {
+      const blob: Blob = new Blob([html], {type: 'application/pdf'});
+      const downloadURL: string = window.URL.createObjectURL(blob);
+
+      const anchor: HTMLAnchorElement = document.createElement("a");
+      anchor.download = fileName;
+      anchor.href = downloadURL;
+      anchor.click();
     });
   }
 
@@ -175,25 +188,15 @@ export class TournamentImagesComponent extends RbacBasedComponent implements OnI
       participant.lastname = names[1];
 
       if (insertedTournamentImageType === TournamentImageType.DIPLOMA) {
-        this.tournamentService.getParticipantDiploma(this.tournament.id, participant).subscribe((html: Blob) => {
-          const blob = new Blob([html], {type: 'application/pdf'});
-          const downloadURL = window.URL.createObjectURL(blob);
-
-          const anchor = document.createElement("a");
-          anchor.download = insertedTournamentImageType + ".pdf";
-          anchor.href = downloadURL;
-          anchor.click();
-        });
+        this.downloadPdfPreview(
+          this.tournamentService.getParticipantDiploma(this.tournament.id, participant),
+          `${insertedTournamentImageType}.pdf`
+        );
       } else {
-        this.tournamentService.getParticipantAccreditation(this.tournament.id, participant, undefined).subscribe((html: Blob) => {
-          const blob = new Blob([html], {type: 'application/pdf'});
-          const downloadURL = window.URL.createObjectURL(blob);
-
-          const anchor = document.createElement("a");
-          anchor.download = insertedTournamentImageType + ".pdf";
-          anchor.href = downloadURL;
-          anchor.click();
-        });
+        this.downloadPdfPreview(
+          this.tournamentService.getParticipantAccreditation(this.tournament.id, participant, undefined),
+          `${insertedTournamentImageType}.pdf`
+        );
       }
     }
   }

--- a/frontend/src/app/views/tournament-list/tournament-list.component.ts
+++ b/frontend/src/app/views/tournament-list/tournament-list.component.ts
@@ -12,7 +12,7 @@ import {RbacBasedComponent} from "../../components/RbacBasedComponent";
 import {SystemOverloadService} from "../../services/notifications/system-overload.service";
 import {AchievementsService} from "../../services/achievements.service";
 import {BiitDatatableComponent, DatatableColumn} from "@biit-solutions/wizardry-theme/table";
-import {combineLatest} from "rxjs";
+import {combineLatest, takeUntil} from "rxjs";
 import {DatePipe} from "@angular/common";
 import {ErrorHandler} from "@biit-solutions/wizardry-theme/utils";
 import {BiitProgressBarType, BiitSnackbarService, NotificationType} from "@biit-solutions/wizardry-theme/info";
@@ -39,8 +39,8 @@ export class TournamentListComponent extends RbacBasedComponent implements After
   protected columns: DatatableColumn[] = [];
   protected pageSize: number = 10;
   protected pageSizes: number[] = [10, 25, 50, 100];
-  protected tournaments: Tournament[];
-  protected target: Tournament | null;
+  protected tournaments: Tournament[] = [];
+  protected target: Tournament | null = null;
   protected confirmDelete: boolean = false;
   protected confirmClone: boolean = false;
   protected showTournamentRoles: boolean = false;
@@ -59,22 +59,17 @@ export class TournamentListComponent extends RbacBasedComponent implements After
 
   public lockedTournaments: (row: Tournament) => boolean = (row) => row.locked;
 
-  constructor(private router: Router, private userSessionService: UserSessionService, private tournamentService: TournamentService,
-              private rankingService: RankingService,
-              private messageService: MessageService, rbacService: RbacService, private systemOverloadService: SystemOverloadService,
-              private achievementsService: AchievementsService, private transloco: TranslocoService, private _datePipe: DatePipe,
-              private biitSnackbarService: BiitSnackbarService, private tableColumnTranslationPipe: TableColumnTranslationPipe) {
+  constructor(private readonly router: Router, private readonly userSessionService: UserSessionService, private readonly tournamentService: TournamentService,
+              private readonly rankingService: RankingService,
+              private readonly messageService: MessageService, rbacService: RbacService, private readonly systemOverloadService: SystemOverloadService,
+              private readonly achievementsService: AchievementsService, private readonly transloco: TranslocoService, private readonly _datePipe: DatePipe,
+              private readonly biitSnackbarService: BiitSnackbarService, private readonly tableColumnTranslationPipe: TableColumnTranslationPipe) {
     super(rbacService);
   }
 
-  datePipe() {
+  datePipe(): { transform: (value?: number | string | Date | null) => string | null } {
     return {
-      transform: (value: any) => {
-        if (!value) {
-          value = 0;
-        }
-        return this._datePipe.transform(value, Constants.FORMAT.DATE);
-      }
+      transform: (value: number | string | Date | null = 0) => this._datePipe.transform(value, Constants.FORMAT.DATE)
     }
   }
 
@@ -93,7 +88,7 @@ export class TournamentListComponent extends RbacBasedComponent implements After
         this.transloco.selectTranslate('updatedBy'),
         this.transloco.selectTranslate('updatedAt'),
       ]
-    ).subscribe(([id, name, type, scoreRules, locked, shiaijos, teamSize, createdBy, createdAt, updatedBy, updatedAt]) => {
+    ).pipe(takeUntil(this.destroySubject)).subscribe(([id, name, type, scoreRules, locked, shiaijos, teamSize, createdBy, createdAt, updatedBy, updatedAt]) => {
       this.columns = [
         new DatatableColumn(id, 'id', false, 80),
         new DatatableColumn(name, 'name'),
@@ -114,13 +109,13 @@ export class TournamentListComponent extends RbacBasedComponent implements After
   loadData(tournament?: Tournament): void {
     this.loading = true;
     this.systemOverloadService.isTransactionalBusy.next(true);
-    this.tournamentService.getAll().subscribe({
+    this.tournamentService.getAll().pipe(takeUntil(this.destroySubject)).subscribe({
       next: (_tournaments: Tournament[]): void => {
         this.tournaments = _tournaments.map(_tournament => Tournament.clone(_tournament)).sort((a: Tournament, b: Tournament): number => {
           return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
         });
       },
-      error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+      error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
     }).add(() => {
       this.loading = false;
       this.systemOverloadService.isTransactionalBusy.next(false);
@@ -144,17 +139,13 @@ export class TournamentListComponent extends RbacBasedComponent implements After
 
   deleteElements(tournaments: Tournament[]): void {
     if (tournaments) {
-      combineLatest(tournaments.map(tournament => this.tournamentService.delete(tournament))).subscribe({
+      combineLatest(tournaments.map(tournament => this.tournamentService.delete(tournament))).pipe(takeUntil(this.destroySubject)).subscribe({
         next: (): void => {
           this.loadData();
           this.confirmDelete = false;
-          this.transloco.selectTranslate('infoTournamentDeleted').subscribe(
-            translation => {
-              this.biitSnackbarService.showNotification(translation, NotificationType.SUCCESS);
-            }
-          );
+          this.biitSnackbarService.showNotification(this.transloco.translate('infoTournamentDeleted'), NotificationType.SUCCESS);
         },
-        error: error => ErrorHandler.notify(error, this.transloco, this.biitSnackbarService)
+          error: error => ErrorHandler.notify(error, this.transloco as never, this.biitSnackbarService)
       });
     }
   }
@@ -184,7 +175,7 @@ export class TournamentListComponent extends RbacBasedComponent implements After
   }
 
   downloadAccreditations(data: { tournament: Tournament, roles: RoleType[], newOnes: boolean }): void {
-    if (data && data.tournament?.id) {
+    if (data?.tournament?.id) {
       this.tournamentService.getAccreditations(data.tournament.id, data.newOnes, data.roles).subscribe((html: Blob): void => {
         if (html !== null) {
           const blob: Blob = new Blob([html], {type: 'application/pdf'});
@@ -205,7 +196,7 @@ export class TournamentListComponent extends RbacBasedComponent implements After
   }
 
   downloadDiplomas(data: { tournament: Tournament, roles: RoleType[], newOnes: boolean }): void {
-    if (data && data.tournament.id) {
+    if (data?.tournament?.id) {
       this.loadingGlobal = true;
       this.tournamentService.getDiplomas(data.tournament.id, data.newOnes, data.roles).subscribe((html: Blob) => {
         if (html !== null) {
@@ -233,12 +224,8 @@ export class TournamentListComponent extends RbacBasedComponent implements After
       tournament.locked = locked;
       if (locked) {
         this.achievementsService.regenerateTournamentAchievements(tournament?.id!).subscribe();
-        if (!tournament.lockedAt) {
-          tournament.lockedAt = new Date();
-        }
-        if (!tournament.finishedAt) {
-          tournament.finishedAt = new Date();
-        }
+        tournament.lockedAt ??= new Date();
+        tournament.finishedAt ??= new Date();
       }
       this.tournamentService.update(tournament).subscribe((_tournament: Tournament): void => {
           this.loadData();
@@ -308,7 +295,7 @@ export class TournamentListComponent extends RbacBasedComponent implements After
   protected readonly BiitProgressBarType = BiitProgressBarType;
 
   selectTournaments(tournaments: Tournament[]) {
-    if (tournaments && tournaments.length == 1) {
+    if (tournaments?.length === 1) {
       this.userSessionService.setSelectedTournament(tournaments[0].id + "");
     } else {
       this.userSessionService.setSelectedTournament(undefined);

--- a/frontend/src/app/views/tournament-list/tournament-teams/tournament-teams.component.html
+++ b/frontend/src/app/views/tournament-list/tournament-teams/tournament-teams.component.html
@@ -123,7 +123,7 @@
         </button>
       }
       <button biit-button id="tournament-button-close"
-        (click)="onClosed.emit()" primary>
+        (click)="closed.emit()" primary>
         {{ t('close') }}
       </button>
     </div>

--- a/frontend/src/app/views/tournament-list/tournament-teams/tournament-teams.component.ts
+++ b/frontend/src/app/views/tournament-list/tournament-teams/tournament-teams.component.ts
@@ -1,9 +1,9 @@
-import {Component, EventEmitter, HostListener, Input, OnInit, Output,} from '@angular/core';
+import {Component, EventEmitter, Input, OnInit, Output,} from '@angular/core';
 import {MessageService} from "../../../services/message.service";
 import {Tournament} from "../../../models/tournament";
 import {RoleType} from "../../../models/role-type";
 import {RoleService} from "../../../services/role.service";
-import {forkJoin, Observable} from "rxjs";
+import {forkJoin, Observable, takeUntil} from "rxjs";
 import {Participant} from "../../../models/participant";
 import {UserListData} from "../../../components/basic/user-list/user-list-data";
 import {CdkDrag, CdkDragDrop, CdkDropList, moveItemInArray} from "@angular/cdk/drag-drop";
@@ -42,7 +42,7 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
 
   @Input()
   tournament: Tournament;
-  @Output() onClosed: EventEmitter<Tournament> = new EventEmitter<Tournament>();
+  @Output() closed: EventEmitter<Tournament> = new EventEmitter<Tournament>();
 
   protected readonly BiitProgressBarType = BiitProgressBarType;
 
@@ -54,13 +54,13 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
   protected addingTeam: boolean = false;
   loadingGlobal: boolean = false;
 
-  constructor(private messageService: MessageService,
-              private loggerService: LoggerService, private teamService: TeamService, private roleService: RoleService,
-              public nameUtilsService: NameUtilsService, private systemOverloadService: SystemOverloadService,
-              rbacService: RbacService, private groupService: GroupService, private fightService: FightService,
-              private rankingService: RankingService, private statisticsChangedService: StatisticsChangedService,
-              private filterResetService: FilterResetService, public csvService: CsvService,
-              private translateService: TranslocoService) {
+  constructor(private readonly messageService: MessageService,
+              private readonly loggerService: LoggerService, private readonly teamService: TeamService, private readonly roleService: RoleService,
+              public nameUtilsService: NameUtilsService, private readonly systemOverloadService: SystemOverloadService,
+              rbacService: RbacService, private readonly groupService: GroupService, private readonly fightService: FightService,
+              private readonly rankingService: RankingService, private readonly statisticsChangedService: StatisticsChangedService,
+              private readonly filterResetService: FilterResetService, public csvService: CsvService,
+              private readonly translateService: TranslocoService) {
     super(rbacService);
   }
 
@@ -71,10 +71,8 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
   ngOnInit(): void {
     let teamsRequest: Observable<Team[]> = this.teamService.getFromTournament(this.tournament);
     let roleRequests: Observable<Role[]> = this.roleService.getFromTournamentAndType(this.tournament.id!, RoleType.COMPETITOR);
-    forkJoin([teamsRequest, roleRequests]).subscribe(([teams, roles]): void => {
-      if (roles === undefined) {
-        roles = [];
-      }
+    forkJoin([teamsRequest, roleRequests]).pipe(takeUntil(this.destroySubject)).subscribe(([teams, roles]): void => {
+      roles ??= [];
       this.userListData.participants = roles.map((role: Role) => role.participant).sort(function (a: Participant, b: Participant) {
         return a.lastname.localeCompare(b.lastname) || a.name.localeCompare(b.name);
       });
@@ -107,15 +105,16 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
       }
     });
     //Get tournament groups
-    this.groupService.getFromTournament(this.tournament.id!).subscribe((_groups: Group[]): void => {
+    this.groupService.getFromTournament(this.tournament.id!).pipe(takeUntil(this.destroySubject)).subscribe((_groups: Group[]): void => {
         this.groups = _groups;
       }
     )
     //Prevent removing teams that are on fights
-    this.fightService.getFromTournament(this.tournament).subscribe((_fights: Fight[]): void => {
-      let teamInFights: Team[] = [];
-      teamInFights.push(..._fights.map((fight: Fight) => fight.team1));
-      teamInFights.push(..._fights.map((fight: Fight) => fight.team2));
+    this.fightService.getFromTournament(this.tournament).pipe(takeUntil(this.destroySubject)).subscribe((_fights: Fight[]): void => {
+      let teamInFights: Team[] = [
+        ..._fights.map((fight: Fight) => fight.team1),
+        ..._fights.map((fight: Fight) => fight.team2)
+      ];
       //Remove duplicates.
       teamInFights = teamInFights.filter((team: Team, i: number, a: Team[]): boolean => i === a.indexOf(team));
       if (this.teams) {
@@ -124,22 +123,6 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
         }
       }
     })
-  }
-
-  onClick(element: EventTarget | null): void {
-    if (!(element instanceof HTMLElement)) {
-      return;
-    }
-    if (!element.classList.contains('team-title-editable') && !element.classList.contains('team-header')) {
-      if (this.teams) {
-        for (let team of this.teams) {
-          if (team.editing) {
-            team.editing = false;
-            this.updateTeamName(team);
-          }
-        }
-      }
-    }
   }
 
   getMember(team: Team, index: number): Participant | undefined {
@@ -228,7 +211,7 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
       const sourceIndex: number | undefined = this.members.get(sourceTeam)?.indexOf(event.item.data);
       if (sourceIndex || sourceIndex === 0) {
         // Moving to an empty space.
-        if (team.members[memberIndex] == undefined) {
+        if (team.members[memberIndex] === undefined) {
           team.members[memberIndex] = participant;
           team.members[sourceIndex] = undefined;
         } else {
@@ -284,7 +267,7 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
 
   searchTeam(event: CdkDragDrop<(Participant | undefined)[], any>): Team | undefined {
     const participant: Participant = event.previousContainer.data[event.previousIndex];
-    for (let team of [...this.members.keys()]) {
+    for (let team of this.members.keys()) {
       if (this.getMembersContainer(team).includes(participant)) {
         return team;
       }
@@ -293,7 +276,7 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
   }
 
   dropListEnterPredicate(memberIndex: number, team: Team) {
-    return function (_item: CdkDrag<Participant>, dropList: CdkDropList): boolean {
+    return function (_item: CdkDrag<Participant>, _dropList: CdkDropList): boolean {
       if (team) {
         return !team.locked && (team.members[memberIndex] === undefined || team.members[memberIndex] === null);
       }
@@ -388,7 +371,7 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
 
   balancedTeams(): void {
     let participants: Participant[];
-    participants = [...Array.prototype.concat.apply([], [...this.members.values()]), ...this.userListData.participants];
+    participants = [...[...this.members.values()].flat().filter((participant): participant is Participant => !!participant), ...this.userListData.participants];
 
     this.loadingGlobal = true;
     this.rankingService.getCompetitorsGlobalScoreRanking(participants, undefined).subscribe((_scoreRanking: ScoreOfCompetitor[]): void => {
@@ -420,7 +403,7 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
 
   randomTeams(): void {
     let participants: Participant[];
-    participants = [...Array.prototype.concat.apply([], [...this.members.values()]), ...this.userListData.participants];
+    participants = [...[...this.members.values()].flat().filter((participant): participant is Participant => !!participant), ...this.userListData.participants];
     for (let team of this.teams) {
       team.members = [];
       for (let i = 0; i < (this.tournament.teamSize ? this.tournament.teamSize : 1); i++) {
@@ -460,7 +443,7 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
   assignTeamByParticipant(): void {
     this.teams = [];
     let participants: Participant[];
-    participants = [...Array.prototype.concat.apply([], [...this.members.values()]), ...this.userListData.participants];
+    participants = [...[...this.members.values()].flat().filter((participant): participant is Participant => !!participant), ...this.userListData.participants];
     this.loadingGlobal = true;
     this.members = new Map<Team, Participant[]>();
     for (const member of participants) {
@@ -507,11 +490,11 @@ export class TournamentTeamsComponent extends RbacBasedComponent implements OnIn
     if (fileList) {
       const file: File | null = fileList.item(0);
       if (file) {
-        this.csvService.addTeams(file, this.tournament.id).subscribe(_teams => {
-          if (_teams.length == 0) {
+        this.csvService.addTeams(file, this.tournament.id).pipe(takeUntil(this.destroySubject)).subscribe(_teams => {
+          if (_teams.length === 0) {
             this.messageService.infoMessage('teamStored');
             //We cancel action or will be saved later again.
-            this.onClosed.emit();
+            this.closed.emit();
           } else {
             const parameters: object = {element: _teams[0].name};
             this.messageService.errorMessage(this.translateService.translate('failedOnCsvField', parameters));


### PR DESCRIPTION
Closes #727

- Fixes several TestNG test classes (`BCryptPasswordConverterTest`, `NameUtilsTests`, `ControllerModelsDTOCoverageTest`, `CsvReaderUnitTest`, `CsvReaderTest`) that were silently excluded from the suite because their `@Test` annotation was missing the required `groups` attribute used by the `testng.xml` group filter. These tests now actually run and contribute to coverage.
- Adds `EncryptedRoundTripCryptoConvertersTests` to exercise the real encryption/decryption path (with a configured key) for the enum, `Long` and `ByteArray` crypto converters, previously only covered through the plain (no-key) path.

Part of the effort to raise backend test coverage towards 95% (#727).